### PR TITLE
Murisi/namada integration

### DIFF
--- a/masp_primitives/Cargo.toml
+++ b/masp_primitives/Cargo.toml
@@ -53,9 +53,6 @@ lazy_static = "1"
 # - Test dependencies
 proptest = { version = "1.0.0", optional = true }
 
-# - Transparent inputs
-secp256k1 = { version = "0.24.1", features = [ "rand" ] }
-
 # - ZIP 339
 bip0039 = { version = "0.9", features = ["std", "all-languages"] }
 

--- a/masp_primitives/src/consensus.rs
+++ b/masp_primitives/src/consensus.rs
@@ -5,11 +5,12 @@ use std::cmp::{Ord, Ordering};
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Add, Bound, RangeBounds, Sub};
+use borsh::{BorshSerialize, BorshDeserialize};
 
 /// A wrapper type representing blockchain heights. Safe conversion from
 /// various integer types, as well as addition and subtraction, are provided.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
 pub struct BlockHeight(u32);
 
 memuse::impl_no_dynamic_usage!(BlockHeight);

--- a/masp_primitives/src/consensus.rs
+++ b/masp_primitives/src/consensus.rs
@@ -1,11 +1,11 @@
 //! Consensus logic and parameters.
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use memuse::DynamicUsage;
 use std::cmp::{Ord, Ordering};
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Add, Bound, RangeBounds, Sub};
-use borsh::{BorshSerialize, BorshDeserialize};
 
 /// A wrapper type representing blockchain heights. Safe conversion from
 /// various integer types, as well as addition and subtraction, are provided.

--- a/masp_primitives/src/lib.rs
+++ b/masp_primitives/src/lib.rs
@@ -30,6 +30,7 @@ pub use group;
 pub use ff;
 pub use jubjub;
 pub use bls12_381;
+pub use secp256k1;
 
 #[cfg(test)]
 mod test_vectors;

--- a/masp_primitives/src/lib.rs
+++ b/masp_primitives/src/lib.rs
@@ -30,7 +30,6 @@ pub use group;
 pub use ff;
 pub use jubjub;
 pub use bls12_381;
-pub use secp256k1;
 
 #[cfg(test)]
 mod test_vectors;

--- a/masp_primitives/src/lib.rs
+++ b/masp_primitives/src/lib.rs
@@ -26,5 +26,10 @@ pub mod sapling;
 pub mod transaction;
 pub mod zip32;
 
+pub use group;
+pub use ff;
+pub use jubjub;
+pub use bls12_381;
+
 #[cfg(test)]
 mod test_vectors;

--- a/masp_primitives/src/lib.rs
+++ b/masp_primitives/src/lib.rs
@@ -26,10 +26,10 @@ pub mod sapling;
 pub mod transaction;
 pub mod zip32;
 
-pub use group;
-pub use ff;
-pub use jubjub;
 pub use bls12_381;
+pub use ff;
+pub use group;
+pub use jubjub;
 
 #[cfg(test)]
 mod test_vectors;

--- a/masp_primitives/src/merkle_tree.rs
+++ b/masp_primitives/src/merkle_tree.rs
@@ -771,7 +771,10 @@ impl<Node: Hashable> BorshDeserialize for MerklePath<Node> {
         // Begin to construct the authentication path
         // Do not use any data in the witness after the expected depth
         let iter = witness[..33 * depth + 8].chunks_exact(33);
-        *witness = iter.remainder();
+        // Update the witness to its final position
+        *witness = &witness[33 * depth + 8..];
+        // Read the position from the witness
+        let position = iter.remainder().read_u64::<LittleEndian>()?;
 
         // The vector works in reverse
         let mut auth_path = iter
@@ -797,9 +800,6 @@ impl<Node: Hashable> BorshDeserialize for MerklePath<Node> {
         if auth_path.len() != depth {
             return Err(std::io::Error::from(std::io::ErrorKind::InvalidData));
         }
-
-        // Read the position from the witness
-        let position = witness.read_u64::<LittleEndian>()?;
 
         // Given the position, let's finish constructing the authentication
         // path

--- a/masp_primitives/src/sapling.rs
+++ b/masp_primitives/src/sapling.rs
@@ -505,7 +505,7 @@ pub enum Rseed {
 }
 
 /// Typesafe wrapper for nullifier values.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize)]
 pub struct Nullifier(pub [u8; 32]);
 
 impl Nullifier {

--- a/masp_primitives/src/sapling.rs
+++ b/masp_primitives/src/sapling.rs
@@ -505,7 +505,9 @@ pub enum Rseed {
 }
 
 /// Typesafe wrapper for nullifier values.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize,
+)]
 pub struct Nullifier(pub [u8; 32]);
 
 impl Nullifier {

--- a/masp_primitives/src/sapling.rs
+++ b/masp_primitives/src/sapling.rs
@@ -85,8 +85,7 @@ pub struct Node {
 }
 
 impl Node {
-    #[cfg(test)]
-    pub(crate) fn new(repr: [u8; 32]) -> Self {
+    pub fn new(repr: [u8; 32]) -> Self {
         Node { repr }
     }
 
@@ -551,7 +550,7 @@ impl From<NoteValue> for u64 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct Note {
     /// The asset type that the note represents
     pub asset_type: AssetType,

--- a/masp_primitives/src/sapling/keys.rs
+++ b/masp_primitives/src/sapling/keys.rs
@@ -8,6 +8,7 @@ use crate::{
     constants::{PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR},
     keys::prf_expand,
 };
+use borsh::{BorshDeserialize, BorshSerialize};
 use ff::PrimeField;
 use group::{Group, GroupEncoding};
 use std::{
@@ -17,7 +18,6 @@ use std::{
     str::FromStr,
 };
 use subtle::CtOption;
-use borsh::{BorshSerialize, BorshDeserialize};
 
 use super::{NullifierDerivingKey, ProofGenerationKey, ViewingKey};
 

--- a/masp_primitives/src/sapling/keys.rs
+++ b/masp_primitives/src/sapling/keys.rs
@@ -17,6 +17,7 @@ use std::{
     str::FromStr,
 };
 use subtle::CtOption;
+use borsh::{BorshSerialize, BorshDeserialize};
 
 use super::{NullifierDerivingKey, ProofGenerationKey, ViewingKey};
 
@@ -31,7 +32,7 @@ pub enum DecodingError {
 }
 
 /// An outgoing viewing key
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
 pub struct OutgoingViewingKey(pub [u8; 32]);
 
 /// A Sapling expanded spending key

--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -10,7 +10,6 @@ use blake2b_simd::Hash as Blake2bHash;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ff::PrimeField;
 use memuse::DynamicUsage;
-pub use secp256k1::PublicKey as TransparentAddress;
 use std::{
     fmt::{self, Debug},
     hash::Hash,
@@ -34,6 +33,9 @@ use self::{
     },
     txid::{to_txid, BlockTxCommitmentDigester, TxIdDigester},
 };
+
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+pub struct TransparentAddress(pub [u8; 20]);
 
 pub const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;
 pub type GrothProofBytes = [u8; GROTH_PROOF_SIZE];

--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -297,10 +297,11 @@ impl BorshDeserialize for Transaction {
 impl borsh::BorshSchema for Transaction {
     fn add_definitions_recursively(
         _definitions: &mut std::collections::HashMap<
-                borsh::schema::Declaration,
+            borsh::schema::Declaration,
             borsh::schema::Definition,
-            >,
-    ) {}
+        >,
+    ) {
+    }
 
     fn declaration() -> borsh::schema::Declaration {
         "Transaction".into()

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -5,7 +5,7 @@ use std::error;
 use std::fmt;
 use std::sync::mpsc::Sender;
 
-use borsh::{BorshSerialize, BorshDeserialize};
+use borsh::{BorshDeserialize, BorshSerialize};
 
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 
@@ -29,7 +29,7 @@ use crate::{
         fees::FeeRule,
         sighash::{signature_hash, SignableInput},
         txid::TxIdDigester,
-        Transaction, TransactionData, TxVersion, Unauthorized, TransparentAddress,
+        Transaction, TransactionData, TransparentAddress, TxVersion, Unauthorized,
     },
     zip32::ExtendedSpendingKey,
 };
@@ -440,8 +440,8 @@ mod testing {
 #[cfg(test)]
 mod tests {
     use ff::Field;
-    use rand_core::OsRng;
     use rand::Rng;
+    use rand_core::OsRng;
 
     use crate::{
         asset_type::AssetType,
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn binding_sig_present_if_shielded_spend() {
         let mut rng = OsRng;
-        
+
         let transparent_address = TransparentAddress(rng.gen::<[u8; 20]>());
 
         let extsk = ExtendedSpendingKey::master(&[]);
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn fails_on_negative_transparent_output() {
         let mut rng = OsRng;
-        
+
         let transparent_address = TransparentAddress(rng.gen::<[u8; 20]>());
         let tx_height = TEST_NETWORK
             .activation_height(NetworkUpgrade::MASP)
@@ -622,12 +622,7 @@ mod tests {
         {
             let mut builder = Builder::new(TEST_NETWORK, tx_height);
             builder
-                .add_sapling_spend(
-                    extsk,
-                    *to.diversifier(),
-                    note1.clone(),
-                    witness1.path().unwrap(),
-                )
+                .add_sapling_spend(extsk, *to.diversifier(), note1, witness1.path().unwrap())
                 .unwrap();
             builder
                 .add_sapling_output(ovk, to, zec(), 30000, MemoBytes::empty())

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -162,6 +162,12 @@ impl<P, R, K, N> Builder<P, R, K, N> {
     pub fn sapling_outputs(&self) -> &[impl sapling::fees::OutputView] {
         self.sapling_builder.outputs()
     }
+
+    /// Returns the set of Sapling converts currently set to be produced by
+    /// the transaction.
+    pub fn sapling_converts(&self) -> &[impl sapling::fees::ConvertView] {
+        self.sapling_builder.converts()
+    }
 }
 
 impl<P: consensus::Parameters> Builder<P, OsRng> {

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -5,6 +5,8 @@ use std::error;
 use std::fmt;
 use std::sync::mpsc::Sender;
 
+use borsh::{BorshSerialize, BorshDeserialize};
+
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 
 use crate::{
@@ -114,14 +116,16 @@ impl Progress {
 }
 
 /// Generates a [`Transaction`] from its inputs and outputs.
-pub struct Builder<P, R> {
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct Builder<P, R, Key = ExtendedSpendingKey, Notifier = Sender<Progress>> {
     params: P,
     rng: R,
     target_height: BlockHeight,
     expiry_height: BlockHeight,
     transparent_builder: TransparentBuilder,
-    sapling_builder: SaplingBuilder<P>,
-    progress_notifier: Option<Sender<Progress>>,
+    sapling_builder: SaplingBuilder<P, Key>,
+    #[borsh_skip]
+    progress_notifier: Option<Notifier>,
 }
 
 impl<P, R> Builder<P, R> {

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -153,7 +153,7 @@ impl<P, R, K, N> Builder<P, R, K, N> {
 
     /// Returns the set of Sapling inputs currently committed to be consumed
     /// by the transaction.
-    pub fn sapling_inputs(&self) -> &[impl sapling::fees::InputView<()>] {
+    pub fn sapling_inputs(&self) -> &[impl sapling::fees::InputView<(), K>] {
         self.sapling_builder.inputs()
     }
 

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -128,7 +128,7 @@ pub struct Builder<P, R, Key = ExtendedSpendingKey, Notifier = Sender<Progress>>
     progress_notifier: Option<Notifier>,
 }
 
-impl<P, R> Builder<P, R> {
+impl<P, R, K, N> Builder<P, R, K, N> {
     /// Returns the network parameters that the builder has been configured for.
     pub fn params(&self) -> &P {
         &self.params

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -5,8 +5,6 @@ use std::error;
 use std::fmt;
 use std::sync::mpsc::Sender;
 
-use secp256k1::PublicKey as TransparentAddress;
-
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 
 use crate::{
@@ -28,7 +26,7 @@ use crate::{
         fees::FeeRule,
         sighash::{signature_hash, SignableInput},
         txid::TxIdDigester,
-        Transaction, TransactionData, TxVersion, Unauthorized,
+        Transaction, TransactionData, TxVersion, Unauthorized, TransparentAddress,
     },
     zip32::ExtendedSpendingKey,
 };

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -422,7 +422,7 @@ mod testing {
 mod tests {
     use ff::Field;
     use rand_core::OsRng;
-    use secp256k1::Secp256k1;
+    use rand::Rng;
 
     use crate::{
         asset_type::AssetType,
@@ -434,6 +434,7 @@ mod tests {
             components::amount::{Amount, DEFAULT_FEE, MAX_MONEY},
             sapling::builder::{self as build_s},
             transparent::builder::{self as build_t},
+            TransparentAddress,
         },
         zip32::ExtendedSpendingKey,
     };
@@ -471,7 +472,9 @@ mod tests {
 
     #[test]
     fn binding_sig_present_if_shielded_spend() {
-        let (_, transparent_address) = Secp256k1::new().generate_keypair(&mut OsRng);
+        let mut rng = OsRng;
+        
+        let transparent_address = TransparentAddress(rng.gen::<[u8; 20]>());
 
         let extsk = ExtendedSpendingKey::master(&[]);
         let dfvk = extsk.to_diversifiable_full_viewing_key();
@@ -515,10 +518,9 @@ mod tests {
 
     #[test]
     fn fails_on_negative_transparent_output() {
-        let secret_key =
-            secp256k1::SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
-        let transparent_address =
-            secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &secret_key);
+        let mut rng = OsRng;
+        
+        let transparent_address = TransparentAddress(rng.gen::<[u8; 20]>());
         let tx_height = TEST_NETWORK
             .activation_height(NetworkUpgrade::MASP)
             .unwrap();
@@ -533,7 +535,7 @@ mod tests {
     fn fails_on_negative_change() {
         let mut rng = OsRng;
 
-        let (_, transparent_address) = Secp256k1::new().generate_keypair(&mut OsRng);
+        let transparent_address = TransparentAddress(rng.gen::<[u8; 20]>());
         // Just use the master key as the ExtendedSpendingKey for this test
         let extsk = ExtendedSpendingKey::master(&[]);
         let tx_height = TEST_NETWORK

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -5,7 +5,7 @@ pub mod sapling;
 pub mod transparent;
 pub use self::{
     amount::Amount,
-    sapling::{OutputDescription, SpendDescription},
+    sapling::{OutputDescription, SpendDescription, ConvertDescription},
     transparent::{TxIn, TxOut},
 };
 

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -5,7 +5,7 @@ pub mod sapling;
 pub mod transparent;
 pub use self::{
     amount::Amount,
-    sapling::{OutputDescription, SpendDescription, ConvertDescription},
+    sapling::{ConvertDescription, OutputDescription, SpendDescription},
     transparent::{TxIn, TxOut},
 };
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -103,7 +103,7 @@ impl<Key: BorshDeserialize> BorshDeserialize for SpendDescriptionInfo<Key> {
     }
 }
 
-impl<K> fees::InputView<()> for SpendDescriptionInfo<K> {
+impl<K> fees::InputView<(), K> for SpendDescriptionInfo<K> {
     fn note_id(&self) -> &() {
         // The builder does not make use of note identifiers, so we can just return the unit value.
         &()
@@ -115,6 +115,10 @@ impl<K> fees::InputView<()> for SpendDescriptionInfo<K> {
 
     fn asset_type(&self) -> AssetType {
         self.note.asset_type
+    }
+
+    fn key(&self) -> &K {
+        &self.extsk
     }
 }
 
@@ -206,6 +210,10 @@ impl fees::OutputView for SaplingOutputInfo {
 
     fn asset_type(&self) -> AssetType {
         self.note.asset_type
+    }
+
+    fn address(&self) -> PaymentAddress {
+        self.to
     }
 }
 
@@ -349,7 +357,7 @@ impl<P, K> SaplingBuilder<P, K> {
 
     /// Returns the list of Sapling inputs that will be consumed by the transaction being
     /// constructed.
-    pub fn inputs(&self) -> &[impl fees::InputView<()>] {
+    pub fn inputs(&self) -> &[impl fees::InputView<(), K>] {
         &self.spends
     }
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -777,6 +777,39 @@ pub struct ConvertDescriptionInfo {
     merkle_path: MerklePath<Node>,
 }
 
+pub trait MapBuilder<P1, K1, P2, K2> {
+    fn map_params(&self, s: P1) -> P2;
+    fn map_key(&self, s: K1) -> K2;
+}
+
+impl<P1, K1> SaplingBuilder<P1, K1> {
+    pub fn map_builder<P2, K2, F: MapBuilder<P1, K1, P2, K2>>(
+        self,
+        f: F,
+    ) -> SaplingBuilder<P2, K2> {
+        SaplingBuilder::<P2, K2> {
+            params: f.map_params(self.params),
+            spend_anchor: self.spend_anchor,
+            target_height: self.target_height,
+            value_balance: self.value_balance,
+            convert_anchor: self.convert_anchor,
+            converts: self.converts,
+            outputs: self.outputs,
+            spends: self
+                .spends
+                .into_iter()
+                .map(|x| SpendDescriptionInfo {
+                    extsk: f.map_key(x.extsk),
+                    diversifier: x.diversifier,
+                    note: x.note,
+                    alpha: x.alpha,
+                    merkle_path: x.merkle_path,
+                })
+                .collect(),
+        }
+    }
+}
+
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use proptest::collection::vec;

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -103,16 +103,18 @@ impl<Key: BorshDeserialize> BorshDeserialize for SpendDescriptionInfo<Key> {
     }
 }
 
-impl fees::InputView<()> for SpendDescriptionInfo {
+impl<K> fees::InputView<()> for SpendDescriptionInfo<K> {
     fn note_id(&self) -> &() {
         // The builder does not make use of note identifiers, so we can just return the unit value.
         &()
     }
 
-    fn value(&self) -> Amount {
-        // An existing note to be spent must have a valid amount value.
-        Amount::from_pair(self.note.asset_type, self.note.value)
-            .expect("Existing note value with invalid asset type or value.")
+    fn value(&self) -> u64 {
+        self.note.value
+    }
+
+    fn asset_type(&self) -> AssetType {
+        self.note.asset_type
     }
 }
 
@@ -198,9 +200,12 @@ impl SaplingOutputInfo {
 }
 
 impl fees::OutputView for SaplingOutputInfo {
-    fn value(&self) -> Amount {
-        Amount::from_pair(self.note.asset_type, self.note.value)
-            .expect("Note values should be checked at construction.")
+    fn value(&self) -> u64 {
+        self.note.value
+    }
+
+    fn asset_type(&self) -> AssetType {
+        self.note.asset_type
     }
 }
 
@@ -328,7 +333,7 @@ impl Authorization for Unauthorized {
     type AuthSig = SpendDescriptionInfo;
 }
 
-impl<P> SaplingBuilder<P> {
+impl<P, K> SaplingBuilder<P, K> {
     pub fn new(params: P, target_height: BlockHeight) -> Self {
         SaplingBuilder {
             params,

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -331,7 +331,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
     ///
     /// Returns an error if the given Merkle path does not have the same anchor as the
     /// paths for previous convert notes.
-    pub fn add_convert<R: RngCore>(
+    pub fn add_convert(
         &mut self,
         allowed: AllowedConversion,
         value: u64,

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -361,7 +361,7 @@ impl<P, K> SaplingBuilder<P, K> {
         &self.spends
     }
 
-    pub fn converts(&self) -> &[ConvertDescriptionInfo] {
+    pub fn converts(&self) -> &[impl fees::ConvertView] {
         &self.converts
     }
     /// Returns the Sapling outputs that will be produced by the transaction being constructed
@@ -788,6 +788,16 @@ pub struct ConvertDescriptionInfo {
     allowed: AllowedConversion,
     value: u64,
     merkle_path: MerklePath<Node>,
+}
+
+impl fees::ConvertView for ConvertDescriptionInfo {
+    fn value(&self) -> u64 {
+        self.value
+    }
+
+    fn conversion(&self) -> &AllowedConversion {
+        &self.allowed
+    }
 }
 
 pub trait MapBuilder<P1, K1, P2, K2> {

--- a/masp_primitives/src/transaction/components/sapling/fees.rs
+++ b/masp_primitives/src/transaction/components/sapling/fees.rs
@@ -2,16 +2,19 @@
 //! of a transaction.
 
 use crate::asset_type::AssetType;
+use crate::sapling::PaymentAddress;
 
 /// A trait that provides a minimized view of a Sapling input suitable for use in
 /// fee and change calculation.
-pub trait InputView<NoteRef> {
+pub trait InputView<NoteRef, Key> {
     /// An identifier for the input being spent.
     fn note_id(&self) -> &NoteRef;
     /// The value of the input being spent.
     fn value(&self) -> u64;
     /// The asset type of the input being spent.
     fn asset_type(&self) -> AssetType;
+    /// The spend/view key of the input being spent.
+    fn key(&self) -> &Key;
 }
 
 /// A trait that provides a minimized view of a Sapling output suitable for use in
@@ -21,4 +24,6 @@ pub trait OutputView {
     fn value(&self) -> u64;
     /// The asset type of the output being produced.
     fn asset_type(&self) -> AssetType;
+    /// The destination of this output
+    fn address(&self) -> PaymentAddress;
 }

--- a/masp_primitives/src/transaction/components/sapling/fees.rs
+++ b/masp_primitives/src/transaction/components/sapling/fees.rs
@@ -1,7 +1,7 @@
 //! Types related to computation of fees and change related to the Sapling components
 //! of a transaction.
 
-use crate::transaction::components::amount::Amount;
+use crate::asset_type::AssetType;
 
 /// A trait that provides a minimized view of a Sapling input suitable for use in
 /// fee and change calculation.
@@ -9,12 +9,16 @@ pub trait InputView<NoteRef> {
     /// An identifier for the input being spent.
     fn note_id(&self) -> &NoteRef;
     /// The value of the input being spent.
-    fn value(&self) -> Amount;
+    fn value(&self) -> u64;
+    /// The asset type of the input being spent.
+    fn asset_type(&self) -> AssetType;
 }
 
 /// A trait that provides a minimized view of a Sapling output suitable for use in
 /// fee and change calculation.
 pub trait OutputView {
     /// The value of the output being produced.
-    fn value(&self) -> Amount;
+    fn value(&self) -> u64;
+    /// The asset type of the output being produced.
+    fn asset_type(&self) -> AssetType;
 }

--- a/masp_primitives/src/transaction/components/sapling/fees.rs
+++ b/masp_primitives/src/transaction/components/sapling/fees.rs
@@ -3,6 +3,7 @@
 
 use crate::asset_type::AssetType;
 use crate::sapling::PaymentAddress;
+use crate::convert::AllowedConversion;
 
 /// A trait that provides a minimized view of a Sapling input suitable for use in
 /// fee and change calculation.
@@ -15,6 +16,15 @@ pub trait InputView<NoteRef, Key> {
     fn asset_type(&self) -> AssetType;
     /// The spend/view key of the input being spent.
     fn key(&self) -> &Key;
+}
+
+/// A trait that provides a minimized view of a Sapling conversion suitable for use in
+/// fee and change calculation.
+pub trait ConvertView {
+    /// The amount of the conversion being used.
+    fn value(&self) -> u64;
+    /// The allowed conversion being used.
+    fn conversion(&self) -> &AllowedConversion;
 }
 
 /// A trait that provides a minimized view of a Sapling output suitable for use in

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -126,7 +126,12 @@ impl TxIn<Authorized> {
             TransparentAddress(tmp)
         };
 
-        Ok(TxIn { asset_type, value, address, transparent_sig: () })
+        Ok(TxIn {
+            asset_type,
+            value,
+            address,
+            transparent_sig: (),
+        })
     }
 
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
@@ -181,7 +186,7 @@ impl TxOut {
         writer.write_all(&self.value.to_le_bytes())?;
         writer.write_all(&self.address.0)
     }
-    
+
     /// Returns the address to which the TxOut was sent, if this is a valid P2SH or P2PKH output.
     pub fn recipient_address(&self) -> TransparentAddress {
         self.address

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -57,6 +57,7 @@ impl fees::InputView for TransparentInputInfo {
     }
 }
 
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct TransparentBuilder {
     #[cfg(feature = "transparent-inputs")]
     inputs: Vec<TransparentInputInfo>,

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -199,18 +199,18 @@ impl TransparentBuilder {
 
 #[cfg(not(feature = "transparent-inputs"))]
 impl TransparentAuthorizingContext for Unauthorized {
-    fn input_amounts(&self) -> Vec<Amount> {
+    fn input_amounts(&self) -> Vec<(AssetType, i64)> {
         vec![]
     }
 }
 
 #[cfg(feature = "transparent-inputs")]
 impl TransparentAuthorizingContext for Unauthorized {
-    fn input_amounts(&self) -> Vec<Result<Amount, ()>> {
+    fn input_amounts(&self) -> Vec<(AssetType, i64)> {
         return self
             .inputs
             .iter()
-            .map(|txin| Amount::from_pair(txin.coin.asset_type, txin.coin.value))
+            .map(|txin| (txin.coin.asset_type, txin.coin.value))
             .collect();
     }
 }

--- a/masp_primitives/src/transaction/components/transparent/fees.rs
+++ b/masp_primitives/src/transaction/components/transparent/fees.rs
@@ -26,6 +26,6 @@ impl OutputView for TxOut {
     }
 
     fn transparent_address(&self) -> &TransparentAddress {
-        &self.transparent_address
+        &self.address
     }
 }

--- a/masp_primitives/src/transaction/components/transparent/fees.rs
+++ b/masp_primitives/src/transaction/components/transparent/fees.rs
@@ -2,7 +2,8 @@
 //! of a transaction.
 
 use super::TxOut;
-use crate::transaction::{components::amount::Amount, TransparentAddress};
+use crate::transaction::TransparentAddress;
+use crate::asset_type::AssetType;
 
 /// This trait provides a minimized view of a transparent input suitable for use in
 /// fee and change computation.
@@ -15,14 +16,20 @@ pub trait InputView {
 /// fee and change computation.
 pub trait OutputView {
     /// Returns the value of the output being created.
-    fn value(&self) -> Amount;
+    fn value(&self) -> i64;
+    /// Returns the asset type of the output being created.
+    fn asset_type(&self) -> AssetType;
     /// Returns the script corresponding to the newly created output.
     fn transparent_address(&self) -> &TransparentAddress;
 }
 
 impl OutputView for TxOut {
-    fn value(&self) -> Amount {
-        Amount::from_pair(self.asset_type, self.value).unwrap()
+    fn value(&self) -> i64 {
+        self.value
+    }
+
+    fn asset_type(&self) -> AssetType {
+        self.asset_type
     }
 
     fn transparent_address(&self) -> &TransparentAddress {

--- a/masp_primitives/src/transaction/sighash.rs
+++ b/masp_primitives/src/transaction/sighash.rs
@@ -5,7 +5,7 @@ use blake2b_simd::Hash as Blake2bHash;
 use super::{
     components::{
         sapling::{self, GrothProofBytes},
-        transparent, Amount,
+        transparent,
     },
     sighash_v5::v5_signature_hash,
     Authorization, TransactionData, TxDigests, TxVersion,
@@ -55,7 +55,7 @@ pub trait TransparentAuthorizingContext: transparent::Authorization {
     /// so that wallets can commit to the transparent input breakdown
     /// without requiring the full data of the previous transactions
     /// providing these inputs.
-    fn input_amounts(&self) -> Vec<Result<Amount, ()>>;
+    fn input_amounts(&self) -> Vec<(AssetType, i64)>;
 }
 
 /// Computes the signature hash for an input to a transaction, given

--- a/masp_primitives/src/transaction/txid.rs
+++ b/masp_primitives/src/transaction/txid.rs
@@ -62,13 +62,18 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
 /// to a hash personalized by ZCASH_INPUTS_HASH_PERSONALIZATION.
 /// In the case that no inputs are provided, this produces a default
 /// hash from just the personalization string.
-pub(crate) fn transparent_inputs_hash<TransparentAuth: transparent::Authorization, T: Borrow<TxIn<TransparentAuth>>>(vin: &[T]) -> Blake2bHash {
+pub(crate) fn transparent_inputs_hash<
+    TransparentAuth: transparent::Authorization,
+    T: Borrow<TxIn<TransparentAuth>>,
+>(
+    vin: &[T],
+) -> Blake2bHash {
     let mut h = hasher(ZCASH_INPUTS_HASH_PERSONALIZATION);
     for t_in in vin {
         let t_in = t_in.borrow();
-        h.write(t_in.asset_type.get_identifier()).unwrap();
-        h.write(&t_in.value.to_le_bytes()).unwrap();
-        h.write(&t_in.address.0).unwrap();
+        h.write_all(t_in.asset_type.get_identifier()).unwrap();
+        h.write_all(&t_in.value.to_le_bytes()).unwrap();
+        h.write_all(&t_in.address.0).unwrap();
     }
     h.finalize()
 }

--- a/masp_primitives/src/transaction/txid.rs
+++ b/masp_primitives/src/transaction/txid.rs
@@ -65,8 +65,10 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
 pub(crate) fn transparent_inputs_hash<TransparentAuth: transparent::Authorization, T: Borrow<TxIn<TransparentAuth>>>(vin: &[T]) -> Blake2bHash {
     let mut h = hasher(ZCASH_INPUTS_HASH_PERSONALIZATION);
     for t_in in vin {
-        h.write(t_in.borrow().asset_type.get_identifier()).unwrap();
-        h.write(&t_in.borrow().value.to_le_bytes()).unwrap();
+        let t_in = t_in.borrow();
+        h.write(t_in.asset_type.get_identifier()).unwrap();
+        h.write(&t_in.value.to_le_bytes()).unwrap();
+        h.write(&t_in.address.0).unwrap();
     }
     h.finalize()
 }
@@ -333,7 +335,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
             for txout in &bundle.vout {
                 h.write_all(txout.asset_type.get_identifier()).unwrap();
                 h.write_all(&txout.value.to_le_bytes()).unwrap();
-                h.write_all(&txout.transparent_address.0).unwrap();
+                h.write_all(&txout.address.0).unwrap();
             }
         }
         h.finalize()

--- a/masp_primitives/src/transaction/txid.rs
+++ b/masp_primitives/src/transaction/txid.rs
@@ -332,7 +332,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
             for txout in &bundle.vout {
                 h.write_all(txout.asset_type.get_identifier()).unwrap();
                 h.write_all(&txout.value.to_le_bytes()).unwrap();
-                h.write_all(&txout.transparent_address.serialize()).unwrap();
+                h.write_all(&txout.transparent_address.0).unwrap();
             }
         }
         h.finalize()

--- a/masp_primitives/src/transaction/txid.rs
+++ b/masp_primitives/src/transaction/txid.rs
@@ -62,10 +62,11 @@ pub(crate) fn transparent_outputs_hash<T: Borrow<TxOut>>(vout: &[T]) -> Blake2bH
 /// to a hash personalized by ZCASH_INPUTS_HASH_PERSONALIZATION.
 /// In the case that no inputs are provided, this produces a default
 /// hash from just the personalization string.
-pub(crate) fn transparent_inputs_hash<T: Borrow<TxIn>>(vin: &[T]) -> Blake2bHash {
+pub(crate) fn transparent_inputs_hash<TransparentAuth: transparent::Authorization, T: Borrow<TxIn<TransparentAuth>>>(vin: &[T]) -> Blake2bHash {
     let mut h = hasher(ZCASH_INPUTS_HASH_PERSONALIZATION);
     for t_in in vin {
-        t_in.borrow().write(&mut h).unwrap();
+        h.write(t_in.borrow().asset_type.get_identifier()).unwrap();
+        h.write(&t_in.borrow().value.to_le_bytes()).unwrap();
     }
     h.finalize()
 }

--- a/masp_proofs/src/lib.rs
+++ b/masp_proofs/src/lib.rs
@@ -15,6 +15,11 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
 
+pub use group;
+pub use bellman;
+pub use jubjub;
+pub use bls12_381;
+
 #[cfg(feature = "directories")]
 use directories::BaseDirs;
 #[cfg(feature = "directories")]

--- a/masp_proofs/src/lib.rs
+++ b/masp_proofs/src/lib.rs
@@ -15,10 +15,10 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
 
-pub use group;
 pub use bellman;
-pub use jubjub;
 pub use bls12_381;
+pub use group;
+pub use jubjub;
 
 #[cfg(feature = "directories")]
 use directories::BaseDirs;


### PR DESCRIPTION
Made some changes to this MASP crate in order to facilitate integration with the Namada crate. More specifically, the changes are as follows:
- Added common traits (i.e. Borsh (de)serialization, Clone, Debug, and PartialOrd) to various objects in cases where they are required by the Namada crate
- Removed the `js` feature from the `getrandom` dependency of the `masp_proofs` crate as this disrupts the compilation of `wasm32-unknown-unknown` modules in the Namada crate
- Made the transaction `Builder` object serializable in order to use it to store/capture the auxiliary inputs that were used to construct a `Transaction`. Having this may be useful for hardware wallets validating a `Transaction`.
- Added a missing function to the `Builder` interface in order to allow for the adding of convert descriptions to a `Transaction`.
- Now re-export some cryptographic crates so that they can be used from the Namada crate.
- Changed `TransparentAddress` to be a byte array (that can be used to store arbitrary hashes) because requiring a `secp256k::PublicKey` was too constraining for the Namada crate which represents `Address`es with `PublicKeyHash`es.
- Actually add input `TransparentAddress`es to the authorized `TxIn`s and include them in the TXID digest. This could be useful for enabling more stringent validation of `Tx` sections in Namada or for combining shielded transactions with non-`Transfer`s.
- Removed the `secp256k` dependency as it would be redundant after the above changes.

See the Namada crate using this branch here: https://github.com/anoma/namada/pull/1280