### PR TITLE
Promote value arithmetic to i128

### DIFF
--- a/masp_primitives/src/asset_type.rs
+++ b/masp_primitives/src/asset_type.rs
@@ -149,14 +149,14 @@ impl AssetType {
     pub fn get_nonce(&self) -> Option<u8> {
         self.nonce
     }
-        /// Deserialize an AssetType object
-        pub fn read<R: Read>(reader: &mut R) -> std::io::Result<Self> {
-            let mut atype = [0; crate::constants::ASSET_IDENTIFIER_LENGTH];
-            reader.read_exact(&mut atype)?;
-            AssetType::from_identifier(&atype).ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid asset type")
-            })
-        }
+    /// Deserialize an AssetType object
+    pub fn read<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut atype = [0; crate::constants::ASSET_IDENTIFIER_LENGTH];
+        reader.read_exact(&mut atype)?;
+        AssetType::from_identifier(&atype).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid asset type")
+        })
+    }
 }
 
 impl PartialEq for AssetType {

--- a/masp_primitives/src/asset_type.rs
+++ b/masp_primitives/src/asset_type.rs
@@ -12,6 +12,7 @@ use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
+    io::Read,
 };
 
 #[derive(Debug, BorshSerialize, BorshDeserialize, Clone, Copy, Eq)]
@@ -148,6 +149,14 @@ impl AssetType {
     pub fn get_nonce(&self) -> Option<u8> {
         self.nonce
     }
+        /// Deserialize an AssetType object
+        pub fn read<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+            let mut atype = [0; crate::constants::ASSET_IDENTIFIER_LENGTH];
+            reader.read_exact(&mut atype)?;
+            AssetType::from_identifier(&atype).ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid asset type")
+            })
+        }
 }
 
 impl PartialEq for AssetType {

--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -16,9 +16,9 @@ use std::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AllowedConversion {
     /// The asset type that the note represents
-    assets: Amount,
+    pub assets: Amount,
     /// Memorize generator because it's expensive to recompute
-    generator: jubjub::ExtendedPoint,
+    pub generator: jubjub::ExtendedPoint,
 }
 
 impl AllowedConversion {

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -273,7 +273,7 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
         &mut self,
         to: &TransparentAddress,
         asset_type: AssetType,
-        value: i64,
+        value: i128,
     ) -> Result<(), transparent::builder::Error> {
         if value < 0 || value > MAX_MONEY {
             return Err(transparent::builder::Error::InvalidAmount);
@@ -502,16 +502,20 @@ mod tests {
             .unwrap();
 
         let mut builder = Builder::new(TEST_NETWORK, masp_activation_height);
-        assert_eq!(
-            builder.add_sapling_output(
-                Some(ovk),
-                to,
-                zec(),
-                MAX_MONEY as u64 + 1,
-                MemoBytes::empty()
-            ),
-            Err(build_s::Error::InvalidAmount)
-        );
+        let value = MAX_MONEY + 1;
+        // Only test overflow if overflow is possible
+        if value <= u64::MAX.into() {
+            assert_eq!(
+                builder.add_sapling_output(
+                    Some(ovk),
+                    to,
+                    zec(),
+                    value.try_into().unwrap(),
+                    MemoBytes::empty()
+                ),
+                Err(build_s::Error::InvalidAmount)
+            );
+        }
     }
 
     /// Generate ZEC asset type

--- a/masp_primitives/src/transaction/components/amount.rs
+++ b/masp_primitives/src/transaction/components/amount.rs
@@ -11,14 +11,14 @@ use std::iter::Sum;
 use std::ops::{Add, AddAssign, Index, Mul, MulAssign, Neg, Sub, SubAssign};
 use zcash_encoding::Vector;
 
-pub const MAX_MONEY: i64 = i64::MAX;
+pub const MAX_MONEY: i128 = u64::MAX as i128;
 lazy_static::lazy_static! {
 pub static ref DEFAULT_FEE: Amount = Amount::from_pair(zec(), 1000).unwrap();
 }
 /// A type-safe representation of some quantity of Zcash.
 ///
 /// An Amount can only be constructed from an integer that is within the valid monetary
-/// range of `{-MAX_MONEY..MAX_MONEY}` (where `MAX_MONEY` = i64::MAX).
+/// range of `{-MAX_MONEY..MAX_MONEY}` (where `MAX_MONEY` = u64::MAX).
 /// However, this range is not preserved as an invariant internally; it is possible to
 /// add two valid Amounts together to obtain an invalid Amount. It is the user's
 /// responsibility to handle the result of serializing potentially-invalid Amounts. In
@@ -27,7 +27,7 @@ pub static ref DEFAULT_FEE: Amount = Amount::from_pair(zec(), 1000).unwrap();
 ///
 #[derive(Clone, Default, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Hash)]
 pub struct Amount<Unit: Hash + Ord + BorshSerialize + BorshDeserialize = AssetType>(
-    pub BTreeMap<Unit, i64>,
+    pub BTreeMap<Unit, i128>,
 );
 
 impl memuse::DynamicUsage for Amount {
@@ -50,10 +50,10 @@ impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> Amount<Unit> 
         Amount(BTreeMap::new())
     }
 
-    /// Creates a non-negative Amount from an i64.
+    /// Creates a non-negative Amount from an i128.
     ///
     /// Returns an error if the amount is outside the range `{0..MAX_MONEY}`.
-    pub fn from_nonnegative<Amt: TryInto<i64>>(atype: Unit, amount: Amt) -> Result<Self, ()> {
+    pub fn from_nonnegative<Amt: TryInto<i128>>(atype: Unit, amount: Amt) -> Result<Self, ()> {
         let amount = amount.try_into().map_err(|_| ())?;
         if amount == 0 {
             Ok(Self::zero())
@@ -65,10 +65,10 @@ impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> Amount<Unit> 
             Err(())
         }
     }
-    /// Creates an Amount from a type convertible to i64.
+    /// Creates an Amount from a type convertible to i128.
     ///
     /// Returns an error if the amount is outside the range `{-MAX_MONEY..MAX_MONEY}`.
-    pub fn from_pair<Amt: TryInto<i64>>(atype: Unit, amount: Amt) -> Result<Self, ()> {
+    pub fn from_pair<Amt: TryInto<i128>>(atype: Unit, amount: Amt) -> Result<Self, ()> {
         let amount = amount.try_into().map_err(|_| ())?;
         if amount == 0 {
             Ok(Self::zero())
@@ -82,17 +82,17 @@ impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> Amount<Unit> 
     }
 
     /// Returns an iterator over the amount's non-zero asset-types
-    pub fn asset_types(&self) -> Keys<'_, Unit, i64> {
+    pub fn asset_types(&self) -> Keys<'_, Unit, i128> {
         self.0.keys()
     }
 
     /// Returns an iterator over the amount's non-zero components
-    pub fn components(&self) -> Iter<'_, Unit, i64> {
+    pub fn components(&self) -> Iter<'_, Unit, i128> {
         self.0.iter()
     }
 
     /// Returns an iterator over the amount's non-zero components
-    pub fn into_components(self) -> IntoIter<Unit, i64> {
+    pub fn into_components(self) -> IntoIter<Unit, i128> {
         self.0.into_iter()
     }
 
@@ -113,14 +113,11 @@ impl Amount<AssetType> {
     /// different assets
     pub fn read<R: Read>(reader: &mut R) -> std::io::Result<Self> {
         let vec = Vector::read(reader, |reader| {
-            let mut atype = [0; 32];
-            let mut value = [0; 8];
-            reader.read_exact(&mut atype)?;
+            let atype = AssetType::read(reader)?;
+            assert_eq!(core::mem::size_of::<i128>(), 16);
+            let mut value = [0; core::mem::size_of::<i128>()];
             reader.read_exact(&mut value)?;
-            let atype = AssetType::from_identifier(&atype).ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid asset type")
-            })?;
-            Ok((atype, i64::from_le_bytes(value)))
+            Ok((atype, i128::from_le_bytes(value)))
         })?;
         let mut ret = Self::zero();
         for (atype, amt) in vec {
@@ -177,17 +174,19 @@ impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> PartialOrd fo
 }
 
 impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize> Index<&Unit> for Amount<Unit> {
-    type Output = i64;
+    type Output = i128;
     /// Query how much of the given asset this amount contains
     fn index(&self, index: &Unit) -> &Self::Output {
         self.0.get(index).unwrap_or(&0)
     }
 }
 
-impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> MulAssign<i64> for Amount<Unit> {
-    fn mul_assign(&mut self, rhs: i64) {
+impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone, RHS: Copy + Into<i128>>
+    MulAssign<RHS> for Amount<Unit>
+{
+    fn mul_assign(&mut self, rhs: RHS) {
         for (_atype, amount) in self.0.iter_mut() {
-            let ent = *amount * rhs;
+            let ent = *amount * rhs.into();
             if -MAX_MONEY <= ent && ent <= MAX_MONEY {
                 *amount = ent;
             } else {
@@ -197,10 +196,12 @@ impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> MulAssign<i64
     }
 }
 
-impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone> Mul<i64> for Amount<Unit> {
+impl<Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone, RHS: Copy + Into<i128>> Mul<RHS>
+    for Amount<Unit>
+{
     type Output = Self;
 
-    fn mul(mut self, rhs: i64) -> Self {
+    fn mul(mut self, rhs: RHS) -> Self {
         self *= rhs;
         self
     }
@@ -364,13 +365,13 @@ pub mod testing {
     }
 
     prop_compose! {
-        pub fn arb_nonnegative_amount()(asset_type in arb_asset_type(), amt in 0i64..MAX_MONEY) -> Amount {
+        pub fn arb_nonnegative_amount()(asset_type in arb_asset_type(), amt in 0i128..MAX_MONEY) -> Amount {
             Amount::from_pair(asset_type, amt).unwrap()
         }
     }
 
     prop_compose! {
-        pub fn arb_positive_amount()(asset_type in arb_asset_type(), amt in 1i64..MAX_MONEY) -> Amount {
+        pub fn arb_positive_amount()(asset_type in arb_asset_type(), amt in 1i128..MAX_MONEY) -> Amount {
             Amount::from_pair(asset_type, amt).unwrap()
         }
     }
@@ -382,38 +383,68 @@ mod tests {
 
     #[test]
     fn amount_in_range() {
-        let zero = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x00\x00\x00\x00\x00\x00\x00\x00";
+        let amount_as_bytes = |name, amount: &Amount| {
+            let mut bytes = [0u8; 49];
+            amount.write(&mut bytes.as_mut()).unwrap();
+            println!(
+                "let {name} = b\"{}\";",
+                std::str::from_utf8(
+                    &bytes
+                        .iter()
+                        .flat_map(|b| std::ascii::escape_default(*b))
+                        .collect::<Vec<_>>()
+                )
+                .unwrap()
+            );
+        };
+
+        amount_as_bytes("zero", &{
+            let mut amount = Amount::from_pair(zec(), 1).unwrap();
+            *amount.0.get_mut(&zec()).unwrap() = 0;
+            amount
+        });
+        amount_as_bytes("neg_one", &Amount::from_pair(zec(), -1).unwrap());
+        amount_as_bytes("max_money", &Amount::from_pair(zec(), MAX_MONEY).unwrap());
+        amount_as_bytes("max_money_p1", &{
+            let mut amount = Amount::from_pair(zec(), MAX_MONEY).unwrap();
+            *amount.0.get_mut(&zec()).unwrap() += 1;
+            amount
+        });
+        amount_as_bytes(
+            "neg_max_money",
+            &Amount::from_pair(zec(), -MAX_MONEY).unwrap(),
+        );
+        amount_as_bytes("neg_max_money_m1", &{
+            let mut amount = Amount::from_pair(zec(), -MAX_MONEY).unwrap();
+            *amount.0.get_mut(&zec()).unwrap() -= 1;
+            amount
+        });
+
+        let zero = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
         assert_eq!(Amount::read(&mut zero.as_ref()).unwrap(), Amount::zero());
 
-        let neg_one = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\xff\xff\xff\xff\xff\xff\xff\xff";
+        let neg_one = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
         assert_eq!(
             Amount::read(&mut neg_one.as_ref()).unwrap(),
             Amount::from_pair(zec(), -1).unwrap()
         );
 
-        let max_money = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\xff\xff\xff\xff\xff\xff\xff\x7f";
-
+        let max_money = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00";
         assert_eq!(
             Amount::read(&mut max_money.as_ref()).unwrap(),
             Amount::from_pair(zec(), MAX_MONEY).unwrap()
         );
 
-        //let max_money_p1 = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x01\x40\x07\x5a\xf0\x75\x07\x00";
-        //assert!(Amount::read(&mut max_money_p1.as_ref()).is_err());
+        let max_money_p1 = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00";
+        assert!(Amount::read(&mut max_money_p1.as_ref()).is_err());
 
-        //let mut neg_max_money = [0u8; 41];
-        //let mut amount = Amount::from_pair(zec(), -MAX_MONEY).unwrap();
-        //*amount.0.get_mut(&zec()).unwrap() = i64::MIN;
-        //amount.write(&mut neg_max_money.as_mut());
-        //dbg!(std::str::from_utf8(&neg_max_money.as_ref().iter().map(|b| std::ascii::escape_default(*b)).flatten().collect::<Vec<_>>()).unwrap());
-
-        let neg_max_money = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x01\x00\x00\x00\x00\x00\x00\x80";
+        let neg_max_money = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x01\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff";
         assert_eq!(
             Amount::read(&mut neg_max_money.as_ref()).unwrap(),
             Amount::from_pair(zec(), -MAX_MONEY).unwrap()
         );
 
-        let neg_max_money_m1 = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x00\x00\x00\x00\x00\x00\x00\x80";
+        let neg_max_money_m1 = b"\x01\x94\xf3O\xfdd\xef\n\xc3i\x08\xfd\xdf\xec\x05hX\x06)\xc4Vq\x0f\xa1\x86\x83\x12\xa8\x7f\xbf\n\xa5\t\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff";
         assert!(Amount::read(&mut neg_max_money_m1.as_ref()).is_err());
     }
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -438,7 +438,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
         }
 
         let allowed_amt: Amount = allowed.clone().into();
-        self.value_balance += allowed_amt * value.try_into().unwrap();
+        self.value_balance += allowed_amt * value;
 
         self.converts.push(ConvertDescriptionInfo {
             allowed,

--- a/masp_primitives/src/transaction/components/sapling/fees.rs
+++ b/masp_primitives/src/transaction/components/sapling/fees.rs
@@ -2,8 +2,8 @@
 //! of a transaction.
 
 use crate::asset_type::AssetType;
-use crate::sapling::PaymentAddress;
 use crate::convert::AllowedConversion;
+use crate::sapling::PaymentAddress;
 
 /// A trait that provides a minimized view of a Sapling input suitable for use in
 /// fee and change calculation.

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -105,10 +105,10 @@ impl TxIn<Authorized> {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let asset_type = AssetType::read(reader)?;
         let value = {
-            assert_eq!(core::mem::size_of::<i128>(), 16);
-            let mut tmp = [0u8; core::mem::size_of::<i128>()];
+            assert_eq!(core::mem::size_of::<u64>(), 8);
+            let mut tmp = [0u8; core::mem::size_of::<u64>()];
             reader.read_exact(&mut tmp)?;
-            i128::from_le_bytes(tmp).into()
+            u64::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(
@@ -148,10 +148,10 @@ impl TxOut {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let asset_type = AssetType::read(reader)?;
         let value = {
-            assert_eq!(core::mem::size_of::<i128>(), 16);
-            let mut tmp = [0u8; core::mem::size_of::<i128>()];
+            assert_eq!(core::mem::size_of::<u64>(), 8);
+            let mut tmp = [0u8; core::mem::size_of::<u64>()];
             reader.read_exact(&mut tmp)?;
-            i128::from_le_bytes(tmp).into()
+            u64::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -105,10 +105,10 @@ impl TxIn<Authorized> {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let asset_type = AssetType::read(reader)?;
         let value = {
-            assert_eq!(core::mem::size_of::<u64>(), 8);
-            let mut tmp = [0u8; core::mem::size_of::<u64>()];
+            assert_eq!(core::mem::size_of::<i128>(), 16);
+            let mut tmp = [0u8; core::mem::size_of::<i128>()];
             reader.read_exact(&mut tmp)?;
-            u64::from_le_bytes(tmp).into()
+            i128::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(
@@ -148,10 +148,10 @@ impl TxOut {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         let asset_type = AssetType::read(reader)?;
         let value = {
-            assert_eq!(core::mem::size_of::<u64>(), 8);
-            let mut tmp = [0u8; core::mem::size_of::<u64>()];
+            assert_eq!(core::mem::size_of::<i128>(), 16);
+            let mut tmp = [0u8; core::mem::size_of::<i128>()];
             reader.read_exact(&mut tmp)?;
-            u64::from_le_bytes(tmp).into()
+            i128::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -96,23 +96,19 @@ impl<A: Authorization> Bundle<A> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxIn<A: Authorization> {
     pub asset_type: AssetType,
-    pub value: i64,
+    pub value: i128,
     pub address: TransparentAddress,
     pub transparent_sig: A::TransparentSig,
 }
 
 impl TxIn<Authorized> {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let asset_type = {
-            let mut tmp = [0u8; 32];
-            reader.read_exact(&mut tmp)?;
-            AssetType::from_identifier(&tmp)
-        }
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid asset identifier"))?;
+        let asset_type = AssetType::read(reader)?;
         let value = {
-            let mut tmp = [0u8; 8];
+            assert_eq!(core::mem::size_of::<u64>(), 8);
+            let mut tmp = [0u8; core::mem::size_of::<u64>()];
             reader.read_exact(&mut tmp)?;
-            i64::from_le_bytes(tmp)
+            u64::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(
@@ -144,22 +140,18 @@ impl TxIn<Authorized> {
 #[derive(Clone, Debug, Hash, PartialOrd, PartialEq, Ord, Eq)]
 pub struct TxOut {
     pub asset_type: AssetType,
-    pub value: i64,
+    pub value: i128,
     pub address: TransparentAddress,
 }
 
 impl TxOut {
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let asset_type = {
-            let mut tmp = [0u8; 32];
-            reader.read_exact(&mut tmp)?;
-            AssetType::from_identifier(&tmp)
-        }
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid asset identifier"))?;
+        let asset_type = AssetType::read(reader)?;
         let value = {
-            let mut tmp = [0u8; 8];
+            assert_eq!(core::mem::size_of::<u64>(), 8);
+            let mut tmp = [0u8; core::mem::size_of::<u64>()];
             reader.read_exact(&mut tmp)?;
-            i64::from_le_bytes(tmp)
+            u64::from_le_bytes(tmp).into()
         };
         if value < 0 || value > MAX_MONEY {
             return Err(io::Error::new(

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -118,7 +118,7 @@ impl TransparentBuilder {
         &mut self,
         to: &TransparentAddress,
         asset_type: AssetType,
-        value: i64,
+        value: i128,
     ) -> Result<(), Error> {
         if value < 0 || value > MAX_MONEY {
             return Err(Error::InvalidAmount);
@@ -164,7 +164,7 @@ impl TransparentBuilder {
             .sum::<Result<Amount, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
-        // Cannot panic when subtracting two positive i64
+        // Cannot panic when subtracting two positive i128
         Ok(input_sum - output_sum)
     }
 
@@ -201,14 +201,14 @@ impl TransparentBuilder {
 
 #[cfg(not(feature = "transparent-inputs"))]
 impl TransparentAuthorizingContext for Unauthorized {
-    fn input_amounts(&self) -> Vec<(AssetType, i64)> {
+    fn input_amounts(&self) -> Vec<(AssetType, i128)> {
         vec![]
     }
 }
 
 #[cfg(feature = "transparent-inputs")]
 impl TransparentAuthorizingContext for Unauthorized {
-    fn input_amounts(&self) -> Vec<(AssetType, i64)> {
+    fn input_amounts(&self) -> Vec<(AssetType, i128)> {
         return self
             .inputs
             .iter()

--- a/masp_primitives/src/transaction/components/transparent/fees.rs
+++ b/masp_primitives/src/transaction/components/transparent/fees.rs
@@ -2,8 +2,8 @@
 //! of a transaction.
 
 use super::TxOut;
-use crate::transaction::TransparentAddress;
 use crate::asset_type::AssetType;
+use crate::transaction::TransparentAddress;
 
 /// This trait provides a minimized view of a transparent input suitable for use in
 /// fee and change computation.
@@ -16,7 +16,7 @@ pub trait InputView {
 /// fee and change computation.
 pub trait OutputView {
     /// Returns the value of the output being created.
-    fn value(&self) -> i64;
+    fn value(&self) -> i128;
     /// Returns the asset type of the output being created.
     fn asset_type(&self) -> AssetType;
     /// Returns the script corresponding to the newly created output.
@@ -24,7 +24,7 @@ pub trait OutputView {
 }
 
 impl OutputView for TxOut {
-    fn value(&self) -> i64 {
+    fn value(&self) -> i128 {
         self.value
     }
 

--- a/masp_primitives/src/transaction/sighash.rs
+++ b/masp_primitives/src/transaction/sighash.rs
@@ -55,7 +55,7 @@ pub trait TransparentAuthorizingContext: transparent::Authorization {
     /// so that wallets can commit to the transparent input breakdown
     /// without requiring the full data of the previous transactions
     /// providing these inputs.
-    fn input_amounts(&self) -> Vec<(AssetType, i64)>;
+    fn input_amounts(&self) -> Vec<(AssetType, i128)>;
 }
 
 /// Computes the signature hash for an input to a transaction, given

--- a/masp_proofs/benches/convert.rs
+++ b/masp_proofs/benches/convert.rs
@@ -34,9 +34,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let output_asset = AssetType::new(format!("asset {}", i + 1).as_bytes()).unwrap();
         let mint_asset = AssetType::new(b"reward").unwrap();
 
-        let spend_value = -(i as i64 + 1);
-        let output_value = i as i64 + 1;
-        let mint_value = i as i64 + 1;
+        let spend_value = -(i as i128 + 1);
+        let output_value = i as i128 + 1;
+        let mint_value = i as i128 + 1;
 
         let allowed_conversion: AllowedConversion = (Amount::from_pair(spend_asset, spend_value)
             .unwrap()

--- a/masp_proofs/src/prover.rs
+++ b/masp_proofs/src/prover.rs
@@ -247,7 +247,7 @@ impl TxProver for LocalTxProver {
     fn binding_sig(
         &self,
         ctx: &mut Self::SaplingProvingContext,
-        assets_and_values: &Amount, //&[(AssetType, i64)],
+        assets_and_values: &Amount,
         sighash: &[u8; 32],
     ) -> Result<Signature, ()> {
         ctx.binding_sig(assets_and_values, sighash)

--- a/masp_proofs/src/sapling/mod.rs
+++ b/masp_proofs/src/sapling/mod.rs
@@ -9,12 +9,11 @@ pub use self::prover::SaplingProvingContext;
 pub use self::verifier::{BatchValidator, SaplingVerificationContext};
 
 // This function computes `value` in the exponent of the value commitment base
-fn masp_compute_value_balance(asset_type: AssetType, value: i64) -> Option<jubjub::ExtendedPoint> {
-    // Compute the absolute value (failing if -i64::MAX is
-    // the value)
+fn masp_compute_value_balance(asset_type: AssetType, value: i128) -> Option<jubjub::ExtendedPoint> {
+    // Compute the absolute value (failing if |value| > u64::MAX)
     let abs = match value.checked_abs() {
-        Some(a) => a as u64,
-        None => return None,
+        Some(a) if a <= u64::MAX.into() => u64::try_from(a).ok()?,
+        _ => return None,
     };
 
     // Is it negative? We'll have to negate later if so.


### PR DESCRIPTION
This does all value arithmetic in i128, which allows u64::MAX value amounts in transactions, and also slightly lessens the risk of overflow problems.