### PR TITLE
Fixed serialization of TxIn and TxOut to support i128.

### DIFF
--- a/masp_primitives/src/sapling/redjubjub.rs
+++ b/masp_primitives/src/sapling/redjubjub.rs
@@ -216,7 +216,7 @@ pub struct BatchEntry<'a> {
 // TODO: #82: This is a naive implementation currently,
 // and doesn't use multiexp.
 pub fn batch_verify<'a, R: RngCore>(
-    mut rng: &mut R,
+    rng: &mut R,
     batch: &[BatchEntry<'a>],
     p_g: SubgroupPoint,
 ) -> bool {
@@ -237,7 +237,7 @@ pub fn batch_verify<'a, R: RngCore>(
 
         let mut c = h_star(&entry.sig.rbar[..], entry.msg);
 
-        let z = jubjub::Fr::random(&mut rng);
+        let z = jubjub::Fr::random(&mut *rng);
 
         s.mul_assign(&z);
         s = s.neg();

--- a/masp_primitives/src/transaction/components/sapling.rs
+++ b/masp_primitives/src/transaction/components/sapling.rs
@@ -498,12 +498,12 @@ pub struct ConvertDescriptionV5 {
 }
 
 impl ConvertDescriptionV5 {
-    pub fn read<R: Read>(mut reader: &mut R) -> io::Result<Self> {
+    pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
         // Consensus rules (§4.4) & (§4.5):
         // - Canonical encoding is enforced here.
         // - "Not small order" is enforced in SaplingVerificationContext::(check_spend()/check_output())
         //   (located in zcash_proofs::sapling::verifier).
-        let cv = read_point(&mut reader, "cv")?;
+        let cv = read_point(reader, "cv")?;
 
         Ok(ConvertDescriptionV5 { cv })
     }


### PR DESCRIPTION
Previously, the values of TxIn and TxOut (which are internally i128) where serialized out in full 16 bytes. However deserialization assumed only 8 bytes. The serialization has been changed to check that the i128 values are really 8 bytes values and then are cast to u64. This can can covered with unit tests.