### PR TITLE
Made Amount more generic.

### DIFF
--- a/masp_primitives/Cargo.toml
+++ b/masp_primitives/Cargo.toml
@@ -36,6 +36,9 @@ sha2 = "0.9"
 # - Metrics
 memuse = "0.2.1"
 
+# - Checked arithmetic
+num-traits = "0.2.14"
+
 # - Secret management
 subtle = "2.2.3"
 

--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -3,7 +3,7 @@ use crate::{
         pedersen_hash::{pedersen_hash, Personalization},
         Node, ValueCommitment,
     },
-    transaction::components::amount::Amount,
+    transaction::components::amount::{Amount, I64Amt},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use group::{Curve, GroupEncoding};
@@ -16,7 +16,7 @@ use std::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AllowedConversion {
     /// The asset type that the note represents
-    assets: Amount,
+    assets: I64Amt,
     /// Memorize generator because it's expensive to recompute
     generator: jubjub::ExtendedPoint,
 }
@@ -71,15 +71,15 @@ impl AllowedConversion {
     }
 }
 
-impl From<AllowedConversion> for Amount {
-    fn from(allowed_conversion: AllowedConversion) -> Amount {
+impl From<AllowedConversion> for I64Amt {
+    fn from(allowed_conversion: AllowedConversion) -> I64Amt {
         allowed_conversion.assets
     }
 }
 
-impl From<Amount> for AllowedConversion {
+impl From<I64Amt> for AllowedConversion {
     /// Produces an asset generator without cofactor cleared
-    fn from(assets: Amount) -> Self {
+    fn from(assets: I64Amt) -> Self {
         let mut asset_generator = jubjub::ExtendedPoint::identity();
         for (asset, value) in assets.components() {
             // Compute the absolute value (failing if -i64::MAX is
@@ -199,11 +199,11 @@ mod tests {
     #[test]
     fn test_homomorphism() {
         // Left operand
-        let a = Amount::from_pair(zec(), 5).unwrap()
-            + Amount::from_pair(btc(), 6).unwrap()
-            + Amount::from_pair(xan(), 7).unwrap();
+        let a = Amount::from_pair(zec(), 5i64).unwrap()
+            + Amount::from_pair(btc(), 6i64).unwrap()
+            + Amount::from_pair(xan(), 7i64).unwrap();
         // Right operand
-        let b = Amount::from_pair(zec(), 2).unwrap() + Amount::from_pair(xan(), 10).unwrap();
+        let b = Amount::from_pair(zec(), 2i64).unwrap() + Amount::from_pair(xan(), 10i64).unwrap();
         // Test homomorphism
         assert_eq!(
             AllowedConversion::from(a.clone() + b.clone()),
@@ -213,9 +213,9 @@ mod tests {
     #[test]
     fn test_serialization() {
         // Make conversion
-        let a: AllowedConversion = (Amount::from_pair(zec(), 5).unwrap()
-            + Amount::from_pair(btc(), 6).unwrap()
-            + Amount::from_pair(xan(), 7).unwrap())
+        let a: AllowedConversion = (Amount::from_pair(zec(), 5i64).unwrap()
+            + Amount::from_pair(btc(), 6i64).unwrap()
+            + Amount::from_pair(xan(), 7i64).unwrap())
         .into();
         // Serialize conversion
         let mut data = Vec::new();

--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -3,7 +3,7 @@ use crate::{
         pedersen_hash::{pedersen_hash, Personalization},
         Node, ValueCommitment,
     },
-    transaction::components::amount::{I64Sum, ValueSum},
+    transaction::components::amount::{I32Sum, ValueSum},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use group::{Curve, GroupEncoding};
@@ -16,7 +16,7 @@ use std::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AllowedConversion {
     /// The asset type that the note represents
-    assets: I64Sum,
+    assets: I32Sum,
     /// Memorize generator because it's expensive to recompute
     generator: jubjub::ExtendedPoint,
 }
@@ -71,15 +71,15 @@ impl AllowedConversion {
     }
 }
 
-impl From<AllowedConversion> for I64Sum {
-    fn from(allowed_conversion: AllowedConversion) -> I64Sum {
+impl From<AllowedConversion> for I32Sum {
+    fn from(allowed_conversion: AllowedConversion) -> I32Sum {
         allowed_conversion.assets
     }
 }
 
-impl From<I64Sum> for AllowedConversion {
+impl From<I32Sum> for AllowedConversion {
     /// Produces an asset generator without cofactor cleared
-    fn from(assets: I64Sum) -> Self {
+    fn from(assets: I32Sum) -> Self {
         let mut asset_generator = jubjub::ExtendedPoint::identity();
         for (asset, value) in assets.components() {
             // Compute the absolute value (failing if -i64::MAX is
@@ -123,7 +123,7 @@ impl BorshDeserialize for AllowedConversion {
     /// computation of checking whether the asset generator corresponds to the
     /// deserialized amount.
     fn deserialize(buf: &mut &[u8]) -> borsh::maybestd::io::Result<Self> {
-        let assets = I64Sum::read(buf)?;
+        let assets = I32Sum::read(buf)?;
         let gen_bytes =
             <<jubjub::ExtendedPoint as GroupEncoding>::Repr as BorshDeserialize>::deserialize(buf)?;
         let generator = Option::from(jubjub::ExtendedPoint::from_bytes(&gen_bytes))
@@ -199,12 +199,12 @@ mod tests {
     #[test]
     fn test_homomorphism() {
         // Left operand
-        let a = ValueSum::from_pair(zec(), 5i64).unwrap()
-            + ValueSum::from_pair(btc(), 6i64).unwrap()
-            + ValueSum::from_pair(xan(), 7i64).unwrap();
+        let a = ValueSum::from_pair(zec(), 5i32).unwrap()
+            + ValueSum::from_pair(btc(), 6i32).unwrap()
+            + ValueSum::from_pair(xan(), 7i32).unwrap();
         // Right operand
         let b =
-            ValueSum::from_pair(zec(), 2i64).unwrap() + ValueSum::from_pair(xan(), 10i64).unwrap();
+            ValueSum::from_pair(zec(), 2i32).unwrap() + ValueSum::from_pair(xan(), 10i32).unwrap();
         // Test homomorphism
         assert_eq!(
             AllowedConversion::from(a.clone() + b.clone()),
@@ -214,9 +214,9 @@ mod tests {
     #[test]
     fn test_serialization() {
         // Make conversion
-        let a: AllowedConversion = (ValueSum::from_pair(zec(), 5i64).unwrap()
-            + ValueSum::from_pair(btc(), 6i64).unwrap()
-            + ValueSum::from_pair(xan(), 7i64).unwrap())
+        let a: AllowedConversion = (ValueSum::from_pair(zec(), 5i32).unwrap()
+            + ValueSum::from_pair(btc(), 6i32).unwrap()
+            + ValueSum::from_pair(xan(), 7i32).unwrap())
         .into();
         // Serialize conversion
         let mut data = Vec::new();

--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -3,7 +3,7 @@ use crate::{
         pedersen_hash::{pedersen_hash, Personalization},
         Node, ValueCommitment,
     },
-    transaction::components::amount::{Amount, I64Amt},
+    transaction::components::amount::{I64Sum, ValueSum},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use group::{Curve, GroupEncoding};
@@ -16,7 +16,7 @@ use std::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AllowedConversion {
     /// The asset type that the note represents
-    assets: I64Amt,
+    assets: I64Sum,
     /// Memorize generator because it's expensive to recompute
     generator: jubjub::ExtendedPoint,
 }
@@ -71,15 +71,15 @@ impl AllowedConversion {
     }
 }
 
-impl From<AllowedConversion> for I64Amt {
-    fn from(allowed_conversion: AllowedConversion) -> I64Amt {
+impl From<AllowedConversion> for I64Sum {
+    fn from(allowed_conversion: AllowedConversion) -> I64Sum {
         allowed_conversion.assets
     }
 }
 
-impl From<I64Amt> for AllowedConversion {
+impl From<I64Sum> for AllowedConversion {
     /// Produces an asset generator without cofactor cleared
-    fn from(assets: I64Amt) -> Self {
+    fn from(assets: I64Sum) -> Self {
         let mut asset_generator = jubjub::ExtendedPoint::identity();
         for (asset, value) in assets.components() {
             // Compute the absolute value (failing if -i64::MAX is
@@ -123,7 +123,7 @@ impl BorshDeserialize for AllowedConversion {
     /// computation of checking whether the asset generator corresponds to the
     /// deserialized amount.
     fn deserialize(buf: &mut &[u8]) -> borsh::maybestd::io::Result<Self> {
-        let assets = Amount::read(buf)?;
+        let assets = I64Sum::read(buf)?;
         let gen_bytes =
             <<jubjub::ExtendedPoint as GroupEncoding>::Repr as BorshDeserialize>::deserialize(buf)?;
         let generator = Option::from(jubjub::ExtendedPoint::from_bytes(&gen_bytes))
@@ -174,7 +174,7 @@ impl SubAssign for AllowedConversion {
 
 impl Sum for AllowedConversion {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(AllowedConversion::from(Amount::zero()), Add::add)
+        iter.fold(AllowedConversion::from(ValueSum::zero()), Add::add)
     }
 }
 
@@ -182,7 +182,7 @@ impl Sum for AllowedConversion {
 mod tests {
     use crate::asset_type::AssetType;
     use crate::convert::AllowedConversion;
-    use crate::transaction::components::amount::Amount;
+    use crate::transaction::components::amount::ValueSum;
 
     /// Generate ZEC asset type
     fn zec() -> AssetType {
@@ -199,11 +199,12 @@ mod tests {
     #[test]
     fn test_homomorphism() {
         // Left operand
-        let a = Amount::from_pair(zec(), 5i64).unwrap()
-            + Amount::from_pair(btc(), 6i64).unwrap()
-            + Amount::from_pair(xan(), 7i64).unwrap();
+        let a = ValueSum::from_pair(zec(), 5i64).unwrap()
+            + ValueSum::from_pair(btc(), 6i64).unwrap()
+            + ValueSum::from_pair(xan(), 7i64).unwrap();
         // Right operand
-        let b = Amount::from_pair(zec(), 2i64).unwrap() + Amount::from_pair(xan(), 10i64).unwrap();
+        let b =
+            ValueSum::from_pair(zec(), 2i64).unwrap() + ValueSum::from_pair(xan(), 10i64).unwrap();
         // Test homomorphism
         assert_eq!(
             AllowedConversion::from(a.clone() + b.clone()),
@@ -213,9 +214,9 @@ mod tests {
     #[test]
     fn test_serialization() {
         // Make conversion
-        let a: AllowedConversion = (Amount::from_pair(zec(), 5i64).unwrap()
-            + Amount::from_pair(btc(), 6i64).unwrap()
-            + Amount::from_pair(xan(), 7i64).unwrap())
+        let a: AllowedConversion = (ValueSum::from_pair(zec(), 5i64).unwrap()
+            + ValueSum::from_pair(btc(), 6i64).unwrap()
+            + ValueSum::from_pair(xan(), 7i64).unwrap())
         .into();
         // Serialize conversion
         let mut data = Vec::new();

--- a/masp_primitives/src/sapling/prover.rs
+++ b/masp_primitives/src/sapling/prover.rs
@@ -8,7 +8,7 @@ use crate::{
         redjubjub::{PublicKey, Signature},
         Node,
     },
-    transaction::components::{Amount, GROTH_PROOF_SIZE},
+    transaction::components::{I64Amt, GROTH_PROOF_SIZE},
 };
 
 use super::{Diversifier, PaymentAddress, ProofGenerationKey, Rseed};
@@ -73,7 +73,7 @@ pub trait TxProver {
     fn binding_sig(
         &self,
         ctx: &mut Self::SaplingProvingContext,
-        amount: &Amount,
+        amount: &I64Amt,
         sighash: &[u8; 32],
     ) -> Result<Signature, ()>;
 }
@@ -92,7 +92,7 @@ pub mod mock {
             redjubjub::{PublicKey, Signature},
             Diversifier, Node, PaymentAddress, ProofGenerationKey, Rseed,
         },
-        transaction::components::{Amount, GROTH_PROOF_SIZE},
+        transaction::components::{I64Amt, GROTH_PROOF_SIZE},
     };
 
     use super::TxProver;
@@ -169,7 +169,7 @@ pub mod mock {
         fn binding_sig(
             &self,
             _ctx: &mut Self::SaplingProvingContext,
-            _value: &Amount,
+            _value: &I64Amt,
             _sighash: &[u8; 32],
         ) -> Result<Signature, ()> {
             Err(())

--- a/masp_primitives/src/sapling/prover.rs
+++ b/masp_primitives/src/sapling/prover.rs
@@ -8,7 +8,7 @@ use crate::{
         redjubjub::{PublicKey, Signature},
         Node,
     },
-    transaction::components::{I64Amt, GROTH_PROOF_SIZE},
+    transaction::components::{I128Sum, GROTH_PROOF_SIZE},
 };
 
 use super::{Diversifier, PaymentAddress, ProofGenerationKey, Rseed};
@@ -73,7 +73,7 @@ pub trait TxProver {
     fn binding_sig(
         &self,
         ctx: &mut Self::SaplingProvingContext,
-        amount: &I64Amt,
+        amount: &I128Sum,
         sighash: &[u8; 32],
     ) -> Result<Signature, ()>;
 }
@@ -92,7 +92,7 @@ pub mod mock {
             redjubjub::{PublicKey, Signature},
             Diversifier, Node, PaymentAddress, ProofGenerationKey, Rseed,
         },
-        transaction::components::{I64Amt, GROTH_PROOF_SIZE},
+        transaction::components::{I128Sum, GROTH_PROOF_SIZE},
     };
 
     use super::TxProver;
@@ -169,7 +169,7 @@ pub mod mock {
         fn binding_sig(
             &self,
             _ctx: &mut Self::SaplingProvingContext,
-            _value: &I64Amt,
+            _value: &I128Sum,
             _sighash: &[u8; 32],
         ) -> Result<Signature, ()> {
             Err(())

--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use self::{
     components::{
-        amount::{Amount, I64Amt},
+        amount::{I128Sum, ValueSum},
         sapling::{
             self, ConvertDescriptionV5, OutputDescriptionV5, SpendDescription, SpendDescriptionV5,
         },
@@ -269,10 +269,10 @@ impl<A: Authorization> TransactionData<A> {
 }
 
 impl<A: Authorization> TransactionData<A> {
-    pub fn sapling_value_balance(&self) -> I64Amt {
+    pub fn sapling_value_balance(&self) -> I128Sum {
         self.sapling_bundle
             .as_ref()
-            .map_or(Amount::zero(), |b| b.value_balance.clone())
+            .map_or(ValueSum::zero(), |b| b.value_balance.clone())
     }
 }
 
@@ -355,8 +355,8 @@ impl Transaction {
         })
     }
 
-    fn read_amount<R: Read>(mut reader: R) -> io::Result<I64Amt> {
-        Amount::read(&mut reader).map_err(|_| {
+    fn read_i128_sum<R: Read>(mut reader: R) -> io::Result<I128Sum> {
+        I128Sum::read(&mut reader).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Amount valueBalance out of range",
@@ -407,9 +407,9 @@ impl Transaction {
         let n_converts = cd_v5s.len();
         let n_outputs = od_v5s.len();
         let value_balance = if n_spends > 0 || n_outputs > 0 {
-            Self::read_amount(&mut reader)?
+            Self::read_i128_sum(&mut reader)?
         } else {
-            Amount::zero()
+            ValueSum::zero()
         };
 
         let spend_anchor = if n_spends > 0 {

--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use self::{
     components::{
-        amount::Amount,
+        amount::{Amount, I64Amt},
         sapling::{
             self, ConvertDescriptionV5, OutputDescriptionV5, SpendDescription, SpendDescriptionV5,
         },
@@ -269,7 +269,7 @@ impl<A: Authorization> TransactionData<A> {
 }
 
 impl<A: Authorization> TransactionData<A> {
-    pub fn sapling_value_balance(&self) -> Amount {
+    pub fn sapling_value_balance(&self) -> I64Amt {
         self.sapling_bundle
             .as_ref()
             .map_or(Amount::zero(), |b| b.value_balance.clone())
@@ -355,7 +355,7 @@ impl Transaction {
         })
     }
 
-    fn read_amount<R: Read>(mut reader: R) -> io::Result<Amount> {
+    fn read_amount<R: Read>(mut reader: R) -> io::Result<I64Amt> {
         Amount::read(&mut reader).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -18,7 +18,7 @@ use crate::{
     sapling::{prover::TxProver, Diversifier, Node, Note, PaymentAddress},
     transaction::{
         components::{
-            amount::{BalanceError, FromNt, I128Sum, U64Sum, ValueSum, MAX_MONEY},
+            amount::{BalanceError, I128Sum, U64Sum, ValueSum, MAX_MONEY},
             sapling::{
                 self,
                 builder::{SaplingBuilder, SaplingMetadata},
@@ -337,7 +337,7 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
         //
 
         // After fees are accounted for, the value balance of the transaction must be zero.
-        let balance_after_fees = self.value_balance()? - I128Sum::from(FromNt(fee));
+        let balance_after_fees = self.value_balance()? - I128Sum::from_sum(fee);
 
         if balance_after_fees != ValueSum::zero() {
             return Err(Error::InsufficientFunds(-balance_after_fees));
@@ -479,7 +479,7 @@ mod tests {
         merkle_tree::{CommitmentTree, IncrementalWitness},
         sapling::Rseed,
         transaction::{
-            components::amount::{FromNt, I128Sum, ValueSum, DEFAULT_FEE},
+            components::amount::{I128Sum, ValueSum, DEFAULT_FEE},
             sapling::builder as build_s,
             TransparentAddress,
         },
@@ -580,7 +580,9 @@ mod tests {
             let builder = Builder::new(TEST_NETWORK, tx_height);
             assert_eq!(
                 builder.mock_build(),
-                Err(Error::InsufficientFunds(FromNt(DEFAULT_FEE.clone()).into()))
+                Err(Error::InsufficientFunds(I128Sum::from_sum(
+                    DEFAULT_FEE.clone()
+                )))
             );
         }
 
@@ -599,7 +601,7 @@ mod tests {
                 builder.mock_build(),
                 Err(Error::InsufficientFunds(
                     I128Sum::from_pair(zec(), 50000).unwrap()
-                        + &I128Sum::from(FromNt(DEFAULT_FEE.clone()))
+                        + &I128Sum::from_sum(DEFAULT_FEE.clone())
                 ))
             );
         }
@@ -615,7 +617,7 @@ mod tests {
                 builder.mock_build(),
                 Err(Error::InsufficientFunds(
                     I128Sum::from_pair(zec(), 50000).unwrap()
-                        + &I128Sum::from(FromNt(DEFAULT_FEE.clone()))
+                        + &I128Sum::from_sum(DEFAULT_FEE.clone())
                 ))
             );
         }

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -597,9 +597,7 @@ mod tests {
             let builder = Builder::new(TEST_NETWORK, tx_height);
             assert_eq!(
                 builder.mock_build(),
-                Err(Error::InsufficientFunds(I128Sum::from(FromNt(
-                    DEFAULT_FEE.clone()
-                ))))
+                Err(Error::InsufficientFunds(FromNt(DEFAULT_FEE.clone()).into()))
             );
         }
 

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -19,7 +19,7 @@ use crate::{
     sapling::{prover::TxProver, Diversifier, Node, Note, PaymentAddress},
     transaction::{
         components::{
-            amount::{Amount, BalanceError, MAX_MONEY},
+            amount::{Amount, BalanceError, I64Amt, MAX_MONEY},
             sapling::{
                 self,
                 builder::{SaplingBuilder, SaplingMetadata},
@@ -43,10 +43,10 @@ const DEFAULT_TX_EXPIRY_DELTA: u32 = 20;
 pub enum Error<FeeError> {
     /// Insufficient funds were provided to the transaction builder; the given
     /// additional amount is required in order to construct the transaction.
-    InsufficientFunds(Amount),
+    InsufficientFunds(I64Amt),
     /// The transaction has inputs in excess of outputs and fees; the user must
     /// add a change output.
-    ChangeRequired(Amount),
+    ChangeRequired(I64Amt),
     /// An error occurred in computing the fees for a transaction.
     Fee(FeeError),
     /// An overflow or underflow occurred when computing value balances
@@ -293,13 +293,13 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
     }
 
     /// Returns the sum of the transparent, Sapling, and TZE value balances.
-    pub fn value_balance(&self) -> Result<Amount, BalanceError> {
+    pub fn value_balance(&self) -> Result<I64Amt, BalanceError> {
         let value_balances = [
             self.transparent_builder.value_balance()?,
             self.sapling_builder.value_balance(),
         ];
 
-        Ok(value_balances.into_iter().sum::<Amount>())
+        Ok(value_balances.into_iter().sum::<I64Amt>())
     }
 
     /// Builds a transaction from the configured spends and outputs.
@@ -326,7 +326,7 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
     fn build_internal<FE>(
         self,
         prover: &impl TxProver,
-        fee: Amount,
+        fee: I64Amt,
     ) -> Result<(Transaction, SaplingMetadata), Error<FE>> {
         let consensus_branch_id = BranchId::for_height(&self.params, self.target_height);
 

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -4,7 +4,7 @@ pub mod amount;
 pub mod sapling;
 pub mod transparent;
 pub use self::{
-    amount::Amount,
+    amount::{Amount, I64Amt},
     sapling::{ConvertDescription, OutputDescription, SpendDescription},
     transparent::{TxIn, TxOut},
 };

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -4,7 +4,10 @@ pub mod amount;
 pub mod sapling;
 pub mod transparent;
 pub use self::{
-    amount::{I128Sum, I64Sum, ValueSum},
+    amount::{
+        FromNt, I128Sum, I16Sum, I32Sum, I64Sum, I8Sum, TryFromNt, U128Sum, U16Sum, U32Sum, U64Sum,
+        U8Sum, ValueSum,
+    },
     sapling::{ConvertDescription, OutputDescription, SpendDescription},
     transparent::{TxIn, TxOut},
 };

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -4,7 +4,7 @@ pub mod amount;
 pub mod sapling;
 pub mod transparent;
 pub use self::{
-    amount::{Amount, I64Amt},
+    amount::{I128Sum, I64Sum, ValueSum},
     sapling::{ConvertDescription, OutputDescription, SpendDescription},
     transparent::{TxIn, TxOut},
 };

--- a/masp_primitives/src/transaction/components.rs
+++ b/masp_primitives/src/transaction/components.rs
@@ -5,8 +5,7 @@ pub mod sapling;
 pub mod transparent;
 pub use self::{
     amount::{
-        FromNt, I128Sum, I16Sum, I32Sum, I64Sum, I8Sum, TryFromNt, U128Sum, U16Sum, U32Sum, U64Sum,
-        U8Sum, ValueSum,
+        I128Sum, I16Sum, I32Sum, I64Sum, I8Sum, U128Sum, U16Sum, U32Sum, U64Sum, U8Sum, ValueSum,
     },
     sapling::{ConvertDescription, OutputDescription, SpendDescription},
     transparent::{TxIn, TxOut},

--- a/masp_primitives/src/transaction/components/amount.rs
+++ b/masp_primitives/src/transaction/components/amount.rs
@@ -35,13 +35,12 @@ pub type I128Amt = Amount<AssetType, i128>;
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Hash)]
 pub struct Amount<
-        Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
+    Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq,
-    > (
-    pub BTreeMap<Unit, Magnitude>,
-);
+>(pub BTreeMap<Unit, Magnitude>);
 
-impl<Unit, Magnitude> memuse::DynamicUsage for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> memuse::DynamicUsage for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd,
 {
@@ -58,7 +57,8 @@ impl<Unit, Magnitude> memuse::DynamicUsage for Amount<Unit, Magnitude> where
     }
 }
 
-impl<Unit, Magnitude> Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd,
 {
@@ -78,7 +78,8 @@ impl<Unit, Magnitude> Amount<Unit, Magnitude> where
     }
 }
 
-impl<Unit, Magnitude> Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
 {
@@ -97,7 +98,7 @@ impl<Unit, Magnitude> Amount<Unit, Magnitude> where
 
     /// Filters out everything but the given AssetType from this Amount
     pub fn project(&self, index: Unit) -> Self {
-        let val = self.0.get(&index).copied().unwrap_or(Magnitude::default());
+        let val = self.0.get(&index).copied().unwrap_or_default();
         Self::from_pair(index, val).unwrap()
     }
 
@@ -107,7 +108,8 @@ impl<Unit, Magnitude> Amount<Unit, Magnitude> where
     }
 }
 
-impl<Unit, Magnitude> Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy,
 {
@@ -174,9 +176,11 @@ impl Amount<AssetType, i64> {
     }
 }
 
-impl<Unit, Magnitude> From<Unit> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> From<Unit> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + From<bool> {
+    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + From<bool>,
+{
     fn from(atype: Unit) -> Self {
         let mut ret = BTreeMap::new();
         ret.insert(atype, true.into());
@@ -184,10 +188,11 @@ impl<Unit, Magnitude> From<Unit> for Amount<Unit, Magnitude> where
     }
 }
 
-impl<Unit, Magnitude> PartialOrd for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> PartialOrd for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd,
-    Self: Sub<Self, Output = Self>
+    Self: Sub<Self, Output = Self>,
 {
     /// One Amount is more than or equal to another if each corresponding
     /// coordinate is more than the other's.
@@ -207,7 +212,8 @@ impl<Unit, Magnitude> PartialOrd for Amount<Unit, Magnitude> where
 
 macro_rules! impl_index {
     ($struct_type:ty) => {
-        impl<Unit> Index<&Unit> for Amount<Unit, $struct_type> where
+        impl<Unit> Index<&Unit> for Amount<Unit, $struct_type>
+        where
             Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
         {
             type Output = $struct_type;
@@ -216,7 +222,7 @@ macro_rules! impl_index {
                 self.0.get(index).unwrap_or(&0)
             }
         }
-    }
+    };
 }
 
 impl_index!(i64);
@@ -225,68 +231,124 @@ impl_index!(u64);
 
 impl_index!(i128);
 
-impl<Unit, Magnitude> MulAssign<Magnitude> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> MulAssign<Magnitude> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedMul,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedMul,
 {
     fn mul_assign(&mut self, rhs: Magnitude) {
         *self = self.clone() * rhs;
     }
 }
 
-impl<Unit, Magnitude> Mul<Magnitude> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Mul<Magnitude> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedMul,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedMul,
 {
     type Output = Amount<Unit, Magnitude>;
 
     fn mul(self, rhs: Magnitude) -> Self::Output {
         let mut comps = BTreeMap::new();
         for (atype, amount) in self.0.iter() {
-            comps.insert(atype.clone(), amount.checked_mul(&rhs).expect("overflow detected"));
+            comps.insert(
+                atype.clone(),
+                amount.checked_mul(&rhs).expect("overflow detected"),
+            );
         }
         comps.retain(|_, v| *v != Magnitude::default());
         Amount(comps)
     }
 }
 
-impl<Unit, Magnitude> AddAssign<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> AddAssign<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedAdd,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedAdd,
 {
     fn add_assign(&mut self, rhs: &Amount<Unit, Magnitude>) {
         *self = self.clone() + rhs;
     }
 }
 
-impl<Unit, Magnitude> AddAssign<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> AddAssign<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedAdd,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedAdd,
 {
     fn add_assign(&mut self, rhs: Amount<Unit, Magnitude>) {
         *self += &rhs
     }
 }
 
-impl<Unit, Magnitude> Add<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Add<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedAdd,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedAdd,
 {
     type Output = Amount<Unit, Magnitude>;
 
     fn add(self, rhs: &Amount<Unit, Magnitude>) -> Self::Output {
         let mut comps = self.0.clone();
         for (atype, amount) in rhs.components() {
-            comps.insert(atype.clone(), self.get(atype).checked_add(amount).expect("overflow detected"));
+            comps.insert(
+                atype.clone(),
+                self.get(atype)
+                    .checked_add(amount)
+                    .expect("overflow detected"),
+            );
         }
         comps.retain(|_, v| *v != Magnitude::default());
         Amount(comps)
     }
 }
 
-impl<Unit, Magnitude> Add<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Add<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedAdd,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedAdd,
 {
     type Output = Amount<Unit, Magnitude>;
 
@@ -295,41 +357,69 @@ impl<Unit, Magnitude> Add<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> w
     }
 }
 
-impl<Unit, Magnitude> SubAssign<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> SubAssign<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedSub,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedSub,
 {
     fn sub_assign(&mut self, rhs: &Amount<Unit, Magnitude>) {
         *self = self.clone() - rhs
     }
 }
 
-impl<Unit, Magnitude> SubAssign<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> SubAssign<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedSub,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedSub,
 {
     fn sub_assign(&mut self, rhs: Amount<Unit, Magnitude>) {
         *self -= &rhs
     }
 }
 
-impl<Unit, Magnitude> Neg for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Neg for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd + CheckedNeg,
+    Magnitude: BorshSerialize
+        + BorshDeserialize
+        + PartialEq
+        + Eq
+        + Copy
+        + Default
+        + PartialOrd
+        + CheckedNeg,
 {
     type Output = Amount<Unit, Magnitude>;
 
     fn neg(mut self) -> Self::Output {
         let mut comps = BTreeMap::new();
         for (atype, amount) in self.0.iter_mut() {
-            comps.insert(atype.clone(), amount.checked_neg().expect("overflow detected"));
+            comps.insert(
+                atype.clone(),
+                amount.checked_neg().expect("overflow detected"),
+            );
         }
         comps.retain(|_, v| *v != Magnitude::default());
         Amount(comps)
     }
 }
 
-impl<Unit, Magnitude> Sub<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Sub<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub,
 {
@@ -338,14 +428,20 @@ impl<Unit, Magnitude> Sub<&Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> 
     fn sub(self, rhs: &Amount<Unit, Magnitude>) -> Self::Output {
         let mut comps = self.0.clone();
         for (atype, amount) in rhs.components() {
-            comps.insert(atype.clone(), self.get(atype).checked_sub(&amount).expect("overflow detected"));
+            comps.insert(
+                atype.clone(),
+                self.get(atype)
+                    .checked_sub(amount)
+                    .expect("overflow detected"),
+            );
         }
         comps.retain(|_, v| *v != Magnitude::default());
         Amount(comps)
     }
 }
 
-impl<Unit, Magnitude> Sub<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Sub<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub,
 {
@@ -356,7 +452,8 @@ impl<Unit, Magnitude> Sub<Amount<Unit, Magnitude>> for Amount<Unit, Magnitude> w
     }
 }
 
-impl<Unit, Magnitude> Sum for Amount<Unit, Magnitude> where
+impl<Unit, Magnitude> Sum for Amount<Unit, Magnitude>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + PartialOrd,
     Self: Add<Output = Self>,
@@ -369,7 +466,8 @@ impl<Unit, Magnitude> Sum for Amount<Unit, Magnitude> where
 /// Workaround for the blanket implementation of TryFrom
 pub struct TryFromNt<X>(pub X);
 
-impl<Unit, Magnitude, Output> TryFrom<TryFromNt<Amount<Unit, Magnitude>>> for Amount<Unit, Output> where
+impl<Unit, Magnitude, Output> TryFrom<TryFromNt<Amount<Unit, Magnitude>>> for Amount<Unit, Output>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy,
     Output: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + TryFrom<Magnitude>,
@@ -378,7 +476,7 @@ impl<Unit, Magnitude, Output> TryFrom<TryFromNt<Amount<Unit, Magnitude>>> for Am
 
     fn try_from(x: TryFromNt<Amount<Unit, Magnitude>>) -> Result<Self, Self::Error> {
         let mut comps = BTreeMap::new();
-        for (atype, amount) in x.0.0 {
+        for (atype, amount) in x.0 .0 {
             comps.insert(atype, amount.try_into()?);
         }
         Ok(Self(comps))
@@ -388,14 +486,15 @@ impl<Unit, Magnitude, Output> TryFrom<TryFromNt<Amount<Unit, Magnitude>>> for Am
 /// Workaround for the blanket implementation of TryFrom
 pub struct FromNt<X>(pub X);
 
-impl<Unit, Magnitude, Output> From<FromNt<Amount<Unit, Magnitude>>> for Amount<Unit, Output> where
+impl<Unit, Magnitude, Output> From<FromNt<Amount<Unit, Magnitude>>> for Amount<Unit, Output>
+where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
     Magnitude: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy,
     Output: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + From<Magnitude>,
 {
     fn from(x: FromNt<Amount<Unit, Magnitude>>) -> Self {
         let mut comps = BTreeMap::new();
-        for (atype, amount) in x.0.0 {
+        for (atype, amount) in x.0 .0 {
             comps.insert(atype, amount.into());
         }
         Self(comps)

--- a/masp_primitives/src/transaction/components/sapling.rs
+++ b/masp_primitives/src/transaction/components/sapling.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 
-use super::{amount::Amount, GROTH_PROOF_SIZE};
+use super::{amount::I64Amt, GROTH_PROOF_SIZE};
 
 pub type GrothProofBytes = [u8; GROTH_PROOF_SIZE];
 
@@ -90,7 +90,7 @@ pub struct Bundle<A: Authorization + PartialEq + BorshSerialize + BorshDeseriali
     pub shielded_spends: Vec<SpendDescription<A>>,
     pub shielded_converts: Vec<ConvertDescription<A::Proof>>,
     pub shielded_outputs: Vec<OutputDescription<A::Proof>>,
-    pub value_balance: Amount,
+    pub value_balance: I64Amt,
     pub authorization: A,
 }
 

--- a/masp_primitives/src/transaction/components/sapling.rs
+++ b/masp_primitives/src/transaction/components/sapling.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 
-use super::{amount::I64Amt, GROTH_PROOF_SIZE};
+use super::{amount::I128Sum, GROTH_PROOF_SIZE};
 
 pub type GrothProofBytes = [u8; GROTH_PROOF_SIZE];
 
@@ -90,7 +90,7 @@ pub struct Bundle<A: Authorization + PartialEq + BorshSerialize + BorshDeseriali
     pub shielded_spends: Vec<SpendDescription<A>>,
     pub shielded_converts: Vec<ConvertDescription<A::Proof>>,
     pub shielded_outputs: Vec<OutputDescription<A::Proof>>,
-    pub value_balance: I64Amt,
+    pub value_balance: I128Sum,
     pub authorization: A,
 }
 
@@ -535,7 +535,7 @@ pub mod testing {
             Nullifier,
         },
         transaction::{
-            components::{amount::testing::arb_amount, GROTH_PROOF_SIZE},
+            components::{amount::testing::arb_i128_sum, GROTH_PROOF_SIZE},
             TxVersion,
         },
     };
@@ -614,7 +614,7 @@ pub mod testing {
             shielded_spends in vec(arb_spend_description(), 0..30),
             shielded_converts in vec(arb_convert_description(), 0..30),
             shielded_outputs in vec(arb_output_description(), 0..30),
-            value_balance in arb_amount(),
+            value_balance in arb_i128_sum(),
             rng_seed in prop::array::uniform32(prop::num::u8::ANY),
             fake_bvk_bytes in prop::array::uniform32(prop::num::u8::ANY),
         ) -> Option<Bundle<Authorized>> {

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction::{
         builder::Progress,
         components::{
-            amount::{FromNt, I128Sum, I64Sum, ValueSum, MAX_MONEY},
+            amount::{FromNt, I128Sum, I32Sum, ValueSum, MAX_MONEY},
             sapling::{
                 fees, Authorization, Authorized, Bundle, ConvertDescription, GrothProofBytes,
                 OutputDescription, SpendDescription,
@@ -401,8 +401,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
         let alpha = jubjub::Fr::random(&mut rng);
 
-        self.value_balance +=
-            ValueSum::from_pair(note.asset_type, note.value.into()).map_err(|_| Error::InvalidAmount)?;
+        self.value_balance += ValueSum::from_pair(note.asset_type, note.value.into())
+            .map_err(|_| Error::InvalidAmount)?;
 
         self.spends.push(SpendDescriptionInfo {
             extsk,
@@ -437,8 +437,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             self.convert_anchor = Some(merkle_path.root(node).into())
         }
 
-        let allowed_amt: I64Sum = allowed.clone().into();
-        self.value_balance += I128Sum::from(FromNt(allowed_amt * (value as i64)));
+        let allowed_amt: I32Sum = allowed.clone().into();
+        self.value_balance += I128Sum::from(FromNt(allowed_amt)) * (value as i128);
 
         self.converts.push(ConvertDescriptionInfo {
             allowed,

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -401,9 +401,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
         let alpha = jubjub::Fr::random(&mut rng);
 
-        self.value_balance += I128Sum::from(FromNt(
-            ValueSum::from_pair(note.asset_type, note.value).map_err(|_| Error::InvalidAmount)?,
-        ));
+        self.value_balance +=
+            ValueSum::from_pair(note.asset_type, note.value.into()).map_err(|_| Error::InvalidAmount)?;
 
         self.spends.push(SpendDescriptionInfo {
             extsk,
@@ -472,9 +471,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             memo,
         )?;
 
-        self.value_balance -= I128Sum::from(FromNt(
-            ValueSum::from_pair(asset_type, value).map_err(|_| Error::InvalidAmount)?,
-        ));
+        self.value_balance -=
+            ValueSum::from_pair(asset_type, value.into()).map_err(|_| Error::InvalidAmount)?;
 
         self.outputs.push(output);
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -146,7 +146,7 @@ impl SaplingOutputInfo {
         memo: MemoBytes,
     ) -> Result<Self, Error> {
         let g_d = to.g_d().ok_or(Error::InvalidAddress)?;
-        if value > MAX_MONEY.try_into().unwrap() {
+        if value > MAX_MONEY {
             return Err(Error::InvalidAmount);
         }
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction::{
         builder::Progress,
         components::{
-            amount::{Amount, I64Amt, I128Amt, TryFromNt, FromNt, MAX_MONEY},
+            amount::{Amount, FromNt, I128Amt, I64Amt, TryFromNt, MAX_MONEY},
             sapling::{
                 fees, Authorization, Authorized, Bundle, ConvertDescription, GrothProofBytes,
                 OutputDescription, SpendDescription,
@@ -411,8 +411,9 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
         let alpha = jubjub::Fr::random(&mut rng);
 
-        self.value_balance +=
-            I128Amt::from(FromNt(Amount::from_pair(note.asset_type, note.value).map_err(|_| Error::InvalidAmount)?));
+        self.value_balance += I128Amt::from(FromNt(
+            Amount::from_pair(note.asset_type, note.value).map_err(|_| Error::InvalidAmount)?,
+        ));
 
         self.spends.push(SpendDescriptionInfo {
             extsk,
@@ -481,8 +482,9 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             memo,
         )?;
 
-        self.value_balance -=
-            I128Amt::from(FromNt(Amount::from_pair(asset_type, value).map_err(|_| Error::InvalidAmount)?));
+        self.value_balance -= I128Amt::from(FromNt(
+            Amount::from_pair(asset_type, value).map_err(|_| Error::InvalidAmount)?,
+        ));
 
         self.outputs.push(output);
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction::{
         builder::Progress,
         components::{
-            amount::{Amount, FromNt, I128Amt, I64Amt, TryFromNt, MAX_MONEY},
+            amount::{FromNt, I128Sum, I64Sum, ValueSum, MAX_MONEY},
             sapling::{
                 fees, Authorization, Authorized, Bundle, ConvertDescription, GrothProofBytes,
                 OutputDescription, SpendDescription,
@@ -272,7 +272,7 @@ pub struct SaplingBuilder<P, Key = ExtendedSpendingKey> {
     params: P,
     spend_anchor: Option<bls12_381::Scalar>,
     target_height: BlockHeight,
-    value_balance: Amount<AssetType, i128>,
+    value_balance: I128Sum,
     convert_anchor: Option<bls12_381::Scalar>,
     spends: Vec<SpendDescriptionInfo<Key>>,
     converts: Vec<ConvertDescriptionInfo>,
@@ -303,7 +303,7 @@ impl<P: BorshDeserialize, Key: BorshDeserialize> BorshDeserialize for SaplingBui
             .map(|x| x.ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidData)))
             .transpose()?;
         let target_height = BlockHeight::deserialize(buf)?;
-        let value_balance = Amount::<AssetType, i128>::deserialize(buf)?;
+        let value_balance = I128Sum::deserialize(buf)?;
         let convert_anchor: Option<Option<_>> =
             Option::<[u8; 32]>::deserialize(buf)?.map(|x| bls12_381::Scalar::from_bytes(&x).into());
         let convert_anchor = convert_anchor
@@ -347,7 +347,7 @@ impl<P, K> SaplingBuilder<P, K> {
             params,
             spend_anchor: None,
             target_height,
-            value_balance: Amount::zero(),
+            value_balance: ValueSum::zero(),
             convert_anchor: None,
             spends: vec![],
             converts: vec![],
@@ -369,19 +369,9 @@ impl<P, K> SaplingBuilder<P, K> {
         &self.outputs
     }
 
-    /// Returns the net value represented by the spends and outputs added to this builder,
-    /// or an error if the values added to this builder overflow the range of a Zcash
-    /// monetary amount.
-    fn try_value_balance(&self) -> Result<I64Amt, Error> {
-        TryFromNt(self.value_balance.clone())
-            .try_into()
-            .map_err(|_| Error::InvalidAmount)
-    }
-
     /// Returns the net value represented by the spends and outputs added to this builder.
-    pub fn value_balance(&self) -> I64Amt {
-        self.try_value_balance()
-            .expect("we check this when mutating self.value_balance")
+    pub fn value_balance(&self) -> I128Sum {
+        self.value_balance.clone()
     }
 }
 
@@ -411,8 +401,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
         let alpha = jubjub::Fr::random(&mut rng);
 
-        self.value_balance += I128Amt::from(FromNt(
-            Amount::from_pair(note.asset_type, note.value).map_err(|_| Error::InvalidAmount)?,
+        self.value_balance += I128Sum::from(FromNt(
+            ValueSum::from_pair(note.asset_type, note.value).map_err(|_| Error::InvalidAmount)?,
         ));
 
         self.spends.push(SpendDescriptionInfo {
@@ -448,8 +438,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             self.convert_anchor = Some(merkle_path.root(node).into())
         }
 
-        let allowed_amt: I64Amt = allowed.clone().into();
-        self.value_balance += I128Amt::from(FromNt(allowed_amt * (value as i64)));
+        let allowed_amt: I64Sum = allowed.clone().into();
+        self.value_balance += I128Sum::from(FromNt(allowed_amt * (value as i64)));
 
         self.converts.push(ConvertDescriptionInfo {
             allowed,
@@ -482,8 +472,8 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             memo,
         )?;
 
-        self.value_balance -= I128Amt::from(FromNt(
-            Amount::from_pair(asset_type, value).map_err(|_| Error::InvalidAmount)?,
+        self.value_balance -= I128Sum::from(FromNt(
+            ValueSum::from_pair(asset_type, value).map_err(|_| Error::InvalidAmount)?,
         ));
 
         self.outputs.push(output);
@@ -500,7 +490,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
         progress_notifier: Option<&Sender<Progress>>,
     ) -> Result<Option<Bundle<Unauthorized>>, Error> {
         // Record initial positions of spends and outputs
-        let value_balance = self.try_value_balance()?;
+        let value_balance = self.value_balance();
         let params = self.params;
         let mut indexed_spends: Vec<_> = self.spends.into_iter().enumerate().collect();
         let mut indexed_converts: Vec<_> = self.converts.into_iter().enumerate().collect();

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction::{
         builder::Progress,
         components::{
-            amount::{FromNt, I128Sum, I32Sum, ValueSum, MAX_MONEY},
+            amount::{I128Sum, I32Sum, ValueSum, MAX_MONEY},
             sapling::{
                 fees, Authorization, Authorized, Bundle, ConvertDescription, GrothProofBytes,
                 OutputDescription, SpendDescription,
@@ -438,7 +438,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
         }
 
         let allowed_amt: I32Sum = allowed.clone().into();
-        self.value_balance += I128Sum::from(FromNt(allowed_amt)) * (value as i128);
+        self.value_balance += I128Sum::from_sum(allowed_amt) * (value as i128);
 
         self.converts.push(ConvertDescriptionInfo {
             allowed,

--- a/masp_primitives/src/transaction/components/sapling/fees.rs
+++ b/masp_primitives/src/transaction/components/sapling/fees.rs
@@ -2,8 +2,8 @@
 //! of a transaction.
 
 use crate::asset_type::AssetType;
-use crate::sapling::PaymentAddress;
 use crate::convert::AllowedConversion;
+use crate::sapling::PaymentAddress;
 
 /// A trait that provides a minimized view of a Sapling input suitable for use in
 /// fee and change calculation.

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read, Write};
 use crate::asset_type::AssetType;
 use crate::transaction::TransparentAddress;
 
-use super::amount::{Amount, BalanceError, I64Amt, MAX_MONEY};
+use super::amount::{BalanceError, I128Sum, ValueSum, MAX_MONEY};
 
 pub mod builder;
 pub mod fees;
@@ -58,7 +58,7 @@ impl<A: Authorization> Bundle<A> {
     /// transferred out of the transparent pool into shielded pools or to fees; a negative value
     /// means that the containing transaction has funds being transferred into the transparent pool
     /// from the shielded pools.
-    pub fn value_balance<E, F>(&self) -> Result<I64Amt, E>
+    pub fn value_balance<E, F>(&self) -> Result<I128Sum, E>
     where
         E: From<BalanceError>,
     {
@@ -67,12 +67,12 @@ impl<A: Authorization> Bundle<A> {
             .iter()
             .map(|p| {
                 if p.value >= 0 {
-                    Amount::from_pair(p.asset_type, p.value)
+                    ValueSum::from_pair(p.asset_type, p.value as i128)
                 } else {
                     Err(())
                 }
             })
-            .sum::<Result<I64Amt, ()>>()
+            .sum::<Result<I128Sum, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         let output_sum = self
@@ -80,12 +80,12 @@ impl<A: Authorization> Bundle<A> {
             .iter()
             .map(|p| {
                 if p.value >= 0 {
-                    Amount::from_pair(p.asset_type, p.value)
+                    ValueSum::from_pair(p.asset_type, p.value as i128)
                 } else {
                     Err(())
                 }
             })
-            .sum::<Result<I64Amt, ()>>()
+            .sum::<Result<I128Sum, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         // Cannot panic when subtracting two positive i64

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -65,26 +65,14 @@ impl<A: Authorization> Bundle<A> {
         let input_sum = self
             .vin
             .iter()
-            .map(|p| {
-                if p.value >= 0 {
-                    ValueSum::from_pair(p.asset_type, p.value as i128)
-                } else {
-                    Err(())
-                }
-            })
+            .map(|p| ValueSum::from_pair(p.asset_type, p.value as i128))
             .sum::<Result<I128Sum, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         let output_sum = self
             .vout
             .iter()
-            .map(|p| {
-                if p.value >= 0 {
-                    ValueSum::from_pair(p.asset_type, p.value as i128)
-                } else {
-                    Err(())
-                }
-            })
+            .map(|p| ValueSum::from_pair(p.asset_type, p.value as i128))
             .sum::<Result<I128Sum, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
@@ -96,7 +84,7 @@ impl<A: Authorization> Bundle<A> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxIn<A: Authorization> {
     pub asset_type: AssetType,
-    pub value: i64,
+    pub value: u64,
     pub address: TransparentAddress,
     pub transparent_sig: A::TransparentSig,
 }
@@ -112,9 +100,9 @@ impl TxIn<Authorized> {
         let value = {
             let mut tmp = [0u8; 8];
             reader.read_exact(&mut tmp)?;
-            i64::from_le_bytes(tmp)
+            u64::from_le_bytes(tmp)
         };
-        if value < 0 || value > MAX_MONEY {
+        if value > MAX_MONEY {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "value out of range",
@@ -144,7 +132,7 @@ impl TxIn<Authorized> {
 #[derive(Clone, Debug, Hash, PartialOrd, PartialEq, Ord, Eq)]
 pub struct TxOut {
     pub asset_type: AssetType,
-    pub value: i64,
+    pub value: u64,
     pub address: TransparentAddress,
 }
 
@@ -159,9 +147,9 @@ impl TxOut {
         let value = {
             let mut tmp = [0u8; 8];
             reader.read_exact(&mut tmp)?;
-            i64::from_le_bytes(tmp)
+            u64::from_le_bytes(tmp)
         };
-        if value < 0 || value > MAX_MONEY {
+        if value > MAX_MONEY {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "value out of range",

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read, Write};
 use crate::asset_type::AssetType;
 use crate::transaction::TransparentAddress;
 
-use super::amount::{Amount, BalanceError, MAX_MONEY};
+use super::amount::{Amount, BalanceError, I64Amt, MAX_MONEY};
 
 pub mod builder;
 pub mod fees;
@@ -58,7 +58,7 @@ impl<A: Authorization> Bundle<A> {
     /// transferred out of the transparent pool into shielded pools or to fees; a negative value
     /// means that the containing transaction has funds being transferred into the transparent pool
     /// from the shielded pools.
-    pub fn value_balance<E, F>(&self) -> Result<Amount, E>
+    pub fn value_balance<E, F>(&self) -> Result<I64Amt, E>
     where
         E: From<BalanceError>,
     {
@@ -72,7 +72,7 @@ impl<A: Authorization> Bundle<A> {
                     Err(())
                 }
             })
-            .sum::<Result<Amount, ()>>()
+            .sum::<Result<I64Amt, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         let output_sum = self
@@ -85,7 +85,7 @@ impl<A: Authorization> Bundle<A> {
                     Err(())
                 }
             })
-            .sum::<Result<Amount, ()>>()
+            .sum::<Result<I64Amt, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         // Cannot panic when subtracting two positive i64

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     asset_type::AssetType,
     transaction::{
         components::{
-            amount::{Amount, BalanceError, MAX_MONEY},
+            amount::{Amount, BalanceError, I64Amt, MAX_MONEY},
             transparent::{self, fees, Authorization, Authorized, Bundle, TxIn, TxOut},
         },
         sighash::TransparentAuthorizingContext,
@@ -133,7 +133,7 @@ impl TransparentBuilder {
         Ok(())
     }
 
-    pub fn value_balance(&self) -> Result<Amount, BalanceError> {
+    pub fn value_balance(&self) -> Result<I64Amt, BalanceError> {
         #[cfg(feature = "transparent-inputs")]
         let input_sum = self
             .inputs
@@ -145,7 +145,7 @@ impl TransparentBuilder {
                     Err(())
                 }
             })
-            .sum::<Result<Amount, ()>>()
+            .sum::<Result<I64Amt, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         #[cfg(not(feature = "transparent-inputs"))]
@@ -161,7 +161,7 @@ impl TransparentBuilder {
                     Err(())
                 }
             })
-            .sum::<Result<Amount, ()>>()
+            .sum::<Result<I64Amt, ()>>()
             .map_err(|_| BalanceError::Overflow)?;
 
         // Cannot panic when subtracting two positive i64

--- a/masp_primitives/src/transaction/components/transparent/fees.rs
+++ b/masp_primitives/src/transaction/components/transparent/fees.rs
@@ -16,7 +16,7 @@ pub trait InputView {
 /// fee and change computation.
 pub trait OutputView {
     /// Returns the value of the output being created.
-    fn value(&self) -> i64;
+    fn value(&self) -> u64;
     /// Returns the asset type of the output being created.
     fn asset_type(&self) -> AssetType;
     /// Returns the script corresponding to the newly created output.
@@ -24,7 +24,7 @@ pub trait OutputView {
 }
 
 impl OutputView for TxOut {
-    fn value(&self) -> i64 {
+    fn value(&self) -> u64 {
         self.value
     }
 

--- a/masp_primitives/src/transaction/components/transparent/fees.rs
+++ b/masp_primitives/src/transaction/components/transparent/fees.rs
@@ -2,8 +2,8 @@
 //! of a transaction.
 
 use super::TxOut;
-use crate::transaction::TransparentAddress;
 use crate::asset_type::AssetType;
+use crate::transaction::TransparentAddress;
 
 /// This trait provides a minimized view of a transparent input suitable for use in
 /// fee and change computation.

--- a/masp_primitives/src/transaction/fees.rs
+++ b/masp_primitives/src/transaction/fees.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{amount::I64Amt, transparent::fees as transparent},
+    transaction::components::{amount::I64Sum, transparent::fees as transparent},
 };
 
 pub mod fixed;
@@ -24,5 +24,5 @@ pub trait FeeRule {
         transparent_outputs: &[impl transparent::OutputView],
         sapling_input_count: usize,
         sapling_output_count: usize,
-    ) -> Result<I64Amt, Self::Error>;
+    ) -> Result<I64Sum, Self::Error>;
 }

--- a/masp_primitives/src/transaction/fees.rs
+++ b/masp_primitives/src/transaction/fees.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{amount::Amount, transparent::fees as transparent},
+    transaction::components::{amount::I64Amt, transparent::fees as transparent},
 };
 
 pub mod fixed;
@@ -24,5 +24,5 @@ pub trait FeeRule {
         transparent_outputs: &[impl transparent::OutputView],
         sapling_input_count: usize,
         sapling_output_count: usize,
-    ) -> Result<Amount, Self::Error>;
+    ) -> Result<I64Amt, Self::Error>;
 }

--- a/masp_primitives/src/transaction/fees.rs
+++ b/masp_primitives/src/transaction/fees.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     consensus::{self, BlockHeight},
-    transaction::components::{amount::I64Sum, transparent::fees as transparent},
+    transaction::components::{amount::U64Sum, transparent::fees as transparent},
 };
 
 pub mod fixed;
@@ -24,5 +24,5 @@ pub trait FeeRule {
         transparent_outputs: &[impl transparent::OutputView],
         sapling_input_count: usize,
         sapling_output_count: usize,
-    ) -> Result<I64Sum, Self::Error>;
+    ) -> Result<U64Sum, Self::Error>;
 }

--- a/masp_primitives/src/transaction/fees/fixed.rs
+++ b/masp_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus::{self, BlockHeight},
     transaction::components::{
-        amount::{Amount, DEFAULT_FEE},
+        amount::{I64Amt, DEFAULT_FEE},
         transparent::fees as transparent,
     },
 };
@@ -10,12 +10,12 @@ use crate::{
 /// the transaction being constructed.
 #[derive(Clone, Debug)]
 pub struct FeeRule {
-    fixed_fee: Amount,
+    fixed_fee: I64Amt,
 }
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
-    pub fn non_standard(fixed_fee: Amount) -> Self {
+    pub fn non_standard(fixed_fee: I64Amt) -> Self {
         Self { fixed_fee }
     }
 
@@ -27,7 +27,7 @@ impl FeeRule {
     }
 
     /// Returns the fixed fee amount which which this rule was configured.
-    pub fn fixed_fee(&self) -> Amount {
+    pub fn fixed_fee(&self) -> I64Amt {
         self.fixed_fee.clone()
     }
 }
@@ -42,7 +42,7 @@ impl super::FeeRule for FeeRule {
         _transparent_outputs: &[impl transparent::OutputView],
         _sapling_input_count: usize,
         _sapling_output_count: usize,
-    ) -> Result<Amount, Self::Error> {
+    ) -> Result<I64Amt, Self::Error> {
         Ok(self.fixed_fee.clone())
     }
 }

--- a/masp_primitives/src/transaction/fees/fixed.rs
+++ b/masp_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus::{self, BlockHeight},
     transaction::components::{
-        amount::{I64Sum, DEFAULT_FEE},
+        amount::{U64Sum, DEFAULT_FEE},
         transparent::fees as transparent,
     },
 };
@@ -10,12 +10,12 @@ use crate::{
 /// the transaction being constructed.
 #[derive(Clone, Debug)]
 pub struct FeeRule {
-    fixed_fee: I64Sum,
+    fixed_fee: U64Sum,
 }
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
-    pub fn non_standard(fixed_fee: I64Sum) -> Self {
+    pub fn non_standard(fixed_fee: U64Sum) -> Self {
         Self { fixed_fee }
     }
 
@@ -27,7 +27,7 @@ impl FeeRule {
     }
 
     /// Returns the fixed fee amount which which this rule was configured.
-    pub fn fixed_fee(&self) -> I64Sum {
+    pub fn fixed_fee(&self) -> U64Sum {
         self.fixed_fee.clone()
     }
 }
@@ -42,7 +42,7 @@ impl super::FeeRule for FeeRule {
         _transparent_outputs: &[impl transparent::OutputView],
         _sapling_input_count: usize,
         _sapling_output_count: usize,
-    ) -> Result<I64Sum, Self::Error> {
+    ) -> Result<U64Sum, Self::Error> {
         Ok(self.fixed_fee.clone())
     }
 }

--- a/masp_primitives/src/transaction/fees/fixed.rs
+++ b/masp_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus::{self, BlockHeight},
     transaction::components::{
-        amount::{I64Amt, DEFAULT_FEE},
+        amount::{I64Sum, DEFAULT_FEE},
         transparent::fees as transparent,
     },
 };
@@ -10,12 +10,12 @@ use crate::{
 /// the transaction being constructed.
 #[derive(Clone, Debug)]
 pub struct FeeRule {
-    fixed_fee: I64Amt,
+    fixed_fee: I64Sum,
 }
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
-    pub fn non_standard(fixed_fee: I64Amt) -> Self {
+    pub fn non_standard(fixed_fee: I64Sum) -> Self {
         Self { fixed_fee }
     }
 
@@ -27,7 +27,7 @@ impl FeeRule {
     }
 
     /// Returns the fixed fee amount which which this rule was configured.
-    pub fn fixed_fee(&self) -> I64Amt {
+    pub fn fixed_fee(&self) -> I64Sum {
         self.fixed_fee.clone()
     }
 }
@@ -42,7 +42,7 @@ impl super::FeeRule for FeeRule {
         _transparent_outputs: &[impl transparent::OutputView],
         _sapling_input_count: usize,
         _sapling_output_count: usize,
-    ) -> Result<I64Amt, Self::Error> {
+    ) -> Result<I64Sum, Self::Error> {
         Ok(self.fixed_fee.clone())
     }
 }

--- a/masp_primitives/src/transaction/sighash.rs
+++ b/masp_primitives/src/transaction/sighash.rs
@@ -55,7 +55,7 @@ pub trait TransparentAuthorizingContext: transparent::Authorization {
     /// so that wallets can commit to the transparent input breakdown
     /// without requiring the full data of the previous transactions
     /// providing these inputs.
-    fn input_amounts(&self) -> Vec<(AssetType, i64)>;
+    fn input_amounts(&self) -> Vec<(AssetType, u64)>;
 }
 
 /// Computes the signature hash for an input to a transaction, given

--- a/masp_proofs/benches/convert.rs
+++ b/masp_proofs/benches/convert.rs
@@ -29,14 +29,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     .unwrap();
 
     c.bench_function("convert", |b| {
-        let i = rng.next_u32();
+        let i = rng.next_u32() >> 1;
         let spend_asset = AssetType::new(format!("asset {}", i).as_bytes()).unwrap();
         let output_asset = AssetType::new(format!("asset {}", i + 1).as_bytes()).unwrap();
         let mint_asset = AssetType::new(b"reward").unwrap();
 
-        let spend_value = -(i as i64 + 1);
-        let output_value = i as i64 + 1;
-        let mint_value = i as i64 + 1;
+        let spend_value = -(i as i32 + 1);
+        let output_value = i as i32 + 1;
+        let mint_value = i as i32 + 1;
 
         let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
             .unwrap()

--- a/masp_proofs/benches/convert.rs
+++ b/masp_proofs/benches/convert.rs
@@ -6,7 +6,7 @@ use bls12_381::Bls12;
 use criterion::Criterion;
 use group::ff::Field;
 use masp_primitives::{
-    asset_type::AssetType, convert::AllowedConversion, transaction::components::Amount,
+    asset_type::AssetType, convert::AllowedConversion, transaction::components::ValueSum,
 };
 use masp_proofs::circuit::convert::{Convert, TREE_DEPTH};
 use rand_core::{RngCore, SeedableRng};
@@ -38,10 +38,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         let output_value = i as i64 + 1;
         let mint_value = i as i64 + 1;
 
-        let allowed_conversion: AllowedConversion = (Amount::from_pair(spend_asset, spend_value)
+        let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
             .unwrap()
-            + Amount::from_pair(output_asset, output_value).unwrap()
-            + Amount::from_pair(mint_asset, mint_value).unwrap())
+            + ValueSum::from_pair(output_asset, output_value).unwrap()
+            + ValueSum::from_pair(mint_asset, mint_value).unwrap())
         .into();
 
         let value = rng.next_u64();

--- a/masp_proofs/src/circuit/convert.rs
+++ b/masp_proofs/src/circuit/convert.rs
@@ -132,7 +132,7 @@ fn test_convert_circuit_with_bls12_381() {
     use group::{ff::Field, ff::PrimeField, ff::PrimeFieldBits, Curve};
     use masp_primitives::{
         asset_type::AssetType, convert::AllowedConversion, sapling::pedersen_hash,
-        transaction::components::Amount,
+        transaction::components::ValueSum,
     };
     use rand_core::{RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
@@ -154,10 +154,10 @@ fn test_convert_circuit_with_bls12_381() {
         let output_value = i as i64 + 1;
         let mint_value = i as i64 + 1;
 
-        let allowed_conversion: AllowedConversion = (Amount::from_pair(spend_asset, spend_value)
+        let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
             .unwrap()
-            + Amount::from_pair(output_asset, output_value).unwrap()
-            + Amount::from_pair(mint_asset, mint_value).unwrap())
+            + ValueSum::from_pair(output_asset, output_value).unwrap()
+            + ValueSum::from_pair(mint_asset, mint_value).unwrap())
         .into();
 
         let value = rng.next_u64();

--- a/masp_proofs/src/circuit/convert.rs
+++ b/masp_proofs/src/circuit/convert.rs
@@ -150,9 +150,9 @@ fn test_convert_circuit_with_bls12_381() {
         let output_asset = AssetType::new(format!("asset {}", i + 1).as_bytes()).unwrap();
         let mint_asset = AssetType::new(b"reward").unwrap();
 
-        let spend_value = -(i as i64 + 1);
-        let output_value = i as i64 + 1;
-        let mint_value = i as i64 + 1;
+        let spend_value = -(i as i32 + 1);
+        let output_value = i as i32 + 1;
+        let mint_value = i as i32 + 1;
 
         let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
             .unwrap()

--- a/masp_proofs/src/prover.rs
+++ b/masp_proofs/src/prover.rs
@@ -11,7 +11,7 @@ use masp_primitives::{
         redjubjub::{PublicKey, Signature},
         Diversifier, Node, PaymentAddress, ProofGenerationKey, Rseed,
     },
-    transaction::components::{Amount, GROTH_PROOF_SIZE},
+    transaction::components::{I64Amt, GROTH_PROOF_SIZE},
 };
 use std::path::Path;
 
@@ -247,7 +247,7 @@ impl TxProver for LocalTxProver {
     fn binding_sig(
         &self,
         ctx: &mut Self::SaplingProvingContext,
-        assets_and_values: &Amount, //&[(AssetType, i64)],
+        assets_and_values: &I64Amt, //&[(AssetType, i64)],
         sighash: &[u8; 32],
     ) -> Result<Signature, ()> {
         ctx.binding_sig(assets_and_values, sighash)

--- a/masp_proofs/src/prover.rs
+++ b/masp_proofs/src/prover.rs
@@ -11,7 +11,7 @@ use masp_primitives::{
         redjubjub::{PublicKey, Signature},
         Diversifier, Node, PaymentAddress, ProofGenerationKey, Rseed,
     },
-    transaction::components::{I64Amt, GROTH_PROOF_SIZE},
+    transaction::components::{I128Sum, GROTH_PROOF_SIZE},
 };
 use std::path::Path;
 
@@ -247,7 +247,7 @@ impl TxProver for LocalTxProver {
     fn binding_sig(
         &self,
         ctx: &mut Self::SaplingProvingContext,
-        assets_and_values: &I64Amt, //&[(AssetType, i64)],
+        assets_and_values: &I128Sum, //&[(AssetType, i64)],
         sighash: &[u8; 32],
     ) -> Result<Signature, ()> {
         ctx.binding_sig(assets_and_values, sighash)

--- a/masp_proofs/src/sapling/mod.rs
+++ b/masp_proofs/src/sapling/mod.rs
@@ -9,11 +9,11 @@ pub use self::prover::SaplingProvingContext;
 pub use self::verifier::{BatchValidator, SaplingVerificationContext};
 
 // This function computes `value` in the exponent of the value commitment base
-fn masp_compute_value_balance(asset_type: AssetType, value: i64) -> Option<jubjub::ExtendedPoint> {
-    // Compute the absolute value (failing if -i64::MAX is
+fn masp_compute_value_balance(asset_type: AssetType, value: i128) -> Option<jubjub::ExtendedPoint> {
+    // Compute the absolute value (failing if -i128::MAX is
     // the value)
     let abs = match value.checked_abs() {
-        Some(a) => a as u64,
+        Some(a) => a as u128,
         None => return None,
     };
 
@@ -21,7 +21,10 @@ fn masp_compute_value_balance(asset_type: AssetType, value: i64) -> Option<jubju
     let is_negative = value.is_negative();
 
     // Compute it in the exponent
-    let mut value_balance = asset_type.value_commitment_generator() * jubjub::Fr::from(abs);
+    let mut abs_bytes = [0u8; 32];
+    abs_bytes[0..16].copy_from_slice(&abs.to_le_bytes());
+    let mut value_balance =
+        asset_type.value_commitment_generator() * jubjub::Fr::from_bytes(&abs_bytes).unwrap();
 
     // Negate if necessary
     if is_negative {

--- a/masp_proofs/src/sapling/prover.rs
+++ b/masp_proofs/src/sapling/prover.rs
@@ -13,7 +13,7 @@ use masp_primitives::{
         redjubjub::{PrivateKey, PublicKey, Signature},
         Diversifier, Node, Note, PaymentAddress, ProofGenerationKey, Rseed,
     },
-    transaction::components::I64Amt,
+    transaction::components::I128Sum,
 };
 use rand_core::OsRng;
 use std::ops::{AddAssign, Neg};
@@ -284,7 +284,7 @@ impl SaplingProvingContext {
     /// and output_proof() must be completed before calling this function.
     pub fn binding_sig(
         &self,
-        assets_and_values: &I64Amt,
+        assets_and_values: &I128Sum,
         sighash: &[u8; 32],
     ) -> Result<Signature, ()> {
         // Initialize secure RNG
@@ -304,7 +304,7 @@ impl SaplingProvingContext {
                 .components()
                 .map(|(asset_type, value_balance)| {
                     // Compute value balance for each asset
-                    // Error for bad value balances (-INT64_MAX value)
+                    // Error for bad value balances (-INT128_MAX value)
                     masp_compute_value_balance(*asset_type, *value_balance)
                 })
                 .try_fold(self.cv_sum, |tmp, value_balance| {

--- a/masp_proofs/src/sapling/prover.rs
+++ b/masp_proofs/src/sapling/prover.rs
@@ -13,7 +13,7 @@ use masp_primitives::{
         redjubjub::{PrivateKey, PublicKey, Signature},
         Diversifier, Node, Note, PaymentAddress, ProofGenerationKey, Rseed,
     },
-    transaction::components::Amount,
+    transaction::components::I64Amt,
 };
 use rand_core::OsRng;
 use std::ops::{AddAssign, Neg};
@@ -284,7 +284,7 @@ impl SaplingProvingContext {
     /// and output_proof() must be completed before calling this function.
     pub fn binding_sig(
         &self,
-        assets_and_values: &Amount,
+        assets_and_values: &I64Amt,
         sighash: &[u8; 32],
     ) -> Result<Signature, ()> {
         // Initialize secure RNG

--- a/masp_proofs/src/sapling/verifier.rs
+++ b/masp_proofs/src/sapling/verifier.rs
@@ -5,7 +5,7 @@ use bls12_381::Bls12;
 use group::{Curve, GroupEncoding};
 use masp_primitives::{
     sapling::redjubjub::{PublicKey, Signature},
-    transaction::components::Amount,
+    transaction::components::I64Amt,
 };
 
 use super::masp_compute_value_balance;
@@ -172,7 +172,7 @@ impl SaplingVerificationContextInner {
     /// have been checked before calling this function.
     fn final_check(
         &self,
-        value_balance: Amount,
+        value_balance: I64Amt,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
         binding_sig_verifier: impl FnOnce(PublicKey, [u8; 64], Signature) -> bool,

--- a/masp_proofs/src/sapling/verifier.rs
+++ b/masp_proofs/src/sapling/verifier.rs
@@ -5,7 +5,7 @@ use bls12_381::Bls12;
 use group::{Curve, GroupEncoding};
 use masp_primitives::{
     sapling::redjubjub::{PublicKey, Signature},
-    transaction::components::I64Amt,
+    transaction::components::I128Sum,
 };
 
 use super::masp_compute_value_balance;
@@ -172,7 +172,7 @@ impl SaplingVerificationContextInner {
     /// have been checked before calling this function.
     fn final_check(
         &self,
-        value_balance: I64Amt,
+        value_balance: I128Sum,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
         binding_sig_verifier: impl FnOnce(PublicKey, [u8; 64], Signature) -> bool,

--- a/masp_proofs/src/sapling/verifier/single.rs
+++ b/masp_proofs/src/sapling/verifier/single.rs
@@ -3,7 +3,7 @@ use bls12_381::Bls12;
 use masp_primitives::{
     constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
     sapling::redjubjub::{PublicKey, Signature},
-    transaction::components::Amount,
+    transaction::components::I64Amt,
 };
 
 use super::SaplingVerificationContextInner;
@@ -98,7 +98,7 @@ impl SaplingVerificationContext {
     /// have been checked before calling this function.
     pub fn final_check(
         &self,
-        value_balance: Amount,
+        value_balance: I64Amt,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
     ) -> bool {

--- a/masp_proofs/src/sapling/verifier/single.rs
+++ b/masp_proofs/src/sapling/verifier/single.rs
@@ -3,7 +3,7 @@ use bls12_381::Bls12;
 use masp_primitives::{
     constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
     sapling::redjubjub::{PublicKey, Signature},
-    transaction::components::I64Amt,
+    transaction::components::I128Sum,
 };
 
 use super::SaplingVerificationContextInner;
@@ -98,7 +98,7 @@ impl SaplingVerificationContext {
     /// have been checked before calling this function.
     pub fn final_check(
         &self,
-        value_balance: I64Amt,
+        value_balance: I128Sum,
         sighash_value: &[u8; 32],
         binding_sig: Signature,
     ) -> bool {


### PR DESCRIPTION
I've been thinking about other approaches to allowing `u64::MAX` notes and eliminating risk of overflow problems. Here's one that came to mind. Specifically, the following changes are made:
* Made `Amount` generic over the integer type (so it can now be `i64`, `128`, or perhaps `i256` or `u256`)
* Added support for overflow/underflow checks using the `Checked*` traits from the `num-traits` library (which is also used in the `namada` repo)
* Everything else is similar to #46 and Zcash, specifically the use of `i128` to accumulate `value_balance`s

The benefits of this approach are that:
* The `Amount` type may be easier to reuse from the `namada` crate (if we somehow use `TokenChange` as the integer type) and may help to avoid having to write `MaspAmount` (at https://github.com/anoma/namada/blob/ec845c28548269deb5d6ce7fef44aa1275c55d82/shared/src/ledger/masp.rs#L427 which is similar to `Amount`)
* `AllowedConversion` can now be backed by a `i64` or `i32` based type, i.e. it is not forced to use a 128 bit based type because of the requirements on `Amount`s in other contexts. Hence space savings.

`MAX_MONEY` values that are smaller than the range of the underlying integer type are not currently supported here, but it should be doable if it is desired. This is just another approach, maybe some of the ideas here could be used to extend #46 ?