### PR TITLE
Murisi/borsh schemas

### DIFF
--- a/masp_note_encryption/src/lib.rs
+++ b/masp_note_encryption/src/lib.rs
@@ -21,6 +21,8 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "alloc")]
+use crate::alloc::string::ToString;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use core::convert::TryInto;
@@ -34,7 +36,7 @@ use cipher::KeyIvInit;
 
 //use crate::constants::ASSET_IDENTIFIER_LENGTH;
 pub const ASSET_IDENTIFIER_LENGTH: usize = 32;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use rand_core::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 
@@ -77,7 +79,18 @@ impl AsRef<[u8]> for OutgoingCipherKey {
 /// Newtype representing the byte encoding of an [`EphemeralPublicKey`].
 ///
 /// [`EphemeralPublicKey`]: Domain::EphemeralPublicKey
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
 pub struct EphemeralKeyBytes(pub [u8; 32]);
 
 impl AsRef<[u8]> for EphemeralKeyBytes {

--- a/masp_primitives/src/asset_type.rs
+++ b/masp_primitives/src/asset_type.rs
@@ -6,6 +6,7 @@ use crate::{
     sapling::ValueCommitment,
 };
 use blake2s_simd::Params as Blake2sParams;
+use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use group::{cofactor::CofactorGroup, Group, GroupEncoding};
 use std::{
@@ -14,7 +15,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[derive(Debug, BorshSerialize, BorshDeserialize, Clone, Copy, Eq)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone, Copy, Eq, BorshSchema)]
 pub struct AssetType {
     identifier: [u8; ASSET_IDENTIFIER_LENGTH], //32 byte asset type preimage
     #[borsh(skip)]

--- a/masp_primitives/src/consensus.rs
+++ b/masp_primitives/src/consensus.rs
@@ -1,6 +1,6 @@
 //! Consensus logic and parameters.
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use memuse::DynamicUsage;
 use std::cmp::{Ord, Ordering};
 use std::convert::TryFrom;
@@ -10,7 +10,9 @@ use std::ops::{Add, Bound, RangeBounds, Sub};
 /// A wrapper type representing blockchain heights. Safe conversion from
 /// various integer types, as well as addition and subtraction, are provided.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub struct BlockHeight(u32);
 
 memuse::impl_no_dynamic_usage!(BlockHeight);

--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -5,8 +5,14 @@ use crate::{
     },
     transaction::components::amount::{I128Sum, ValueSum},
 };
+use borsh::schema::add_definition;
+use borsh::schema::Declaration;
+use borsh::schema::Definition;
+use borsh::schema::Fields;
+use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use group::{Curve, GroupEncoding};
+use std::collections::BTreeMap;
 use std::{
     io::{self, Write},
     iter::Sum,
@@ -107,6 +113,24 @@ impl From<I128Sum> for AllowedConversion {
             assets,
             generator: asset_generator,
         }
+    }
+}
+
+impl BorshSchema for AllowedConversion {
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("assets".into(), I128Sum::declaration()),
+                ("generator".into(), <[u8; 32]>::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        I128Sum::add_definitions_recursively(definitions);
+        <[u8; 32]>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        "AllowedConversion".into()
     }
 }
 

--- a/masp_primitives/src/memo.rs
+++ b/masp_primitives/src/memo.rs
@@ -1,6 +1,6 @@
 //! Structs for handling encrypted memos.
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 use std::error;
@@ -48,7 +48,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 /// The unencrypted memo bytes received alongside a shielded note in a Zcash transaction.
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct MemoBytes(pub(crate) Box<[u8; 512]>);
 
 impl fmt::Debug for MemoBytes {

--- a/masp_primitives/src/sapling.rs
+++ b/masp_primitives/src/sapling.rs
@@ -639,7 +639,17 @@ impl BorshDeserialize for Rseed {
 
 /// Typesafe wrapper for nullifier values.
 #[derive(
-    Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
 )]
 pub struct Nullifier(pub [u8; 32]);
 

--- a/masp_primitives/src/sapling/keys.rs
+++ b/masp_primitives/src/sapling/keys.rs
@@ -8,6 +8,7 @@ use crate::{
     constants::{PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR},
     keys::prf_expand,
 };
+use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ff::PrimeField;
 use group::{Group, GroupEncoding};
@@ -32,7 +33,9 @@ pub enum DecodingError {
 }
 
 /// An outgoing viewing key
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub struct OutgoingViewingKey(pub [u8; 32]);
 
 /// A Sapling expanded spending key

--- a/masp_primitives/src/sapling/keys.rs
+++ b/masp_primitives/src/sapling/keys.rs
@@ -8,10 +8,15 @@ use crate::{
     constants::{PROOF_GENERATION_KEY_GENERATOR, SPENDING_KEY_GENERATOR},
     keys::prf_expand,
 };
+use borsh::schema::add_definition;
+use borsh::schema::Declaration;
+use borsh::schema::Definition;
+use borsh::schema::Fields;
 use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ff::PrimeField;
 use group::{Group, GroupEncoding};
+use std::collections::BTreeMap;
 use std::{
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
@@ -208,6 +213,36 @@ impl FullViewingKey {
         self.write(&mut result[..])
             .expect("should be able to serialize a FullViewingKey");
         result
+    }
+}
+
+impl BorshSerialize for FullViewingKey {
+    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.write(writer)
+    }
+}
+
+impl BorshDeserialize for FullViewingKey {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> io::Result<Self> {
+        Self::read(reader)
+    }
+}
+
+impl BorshSchema for FullViewingKey {
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("vk".into(), ViewingKey::declaration()),
+                ("ovk".into(), OutgoingViewingKey::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        ViewingKey::add_definitions_recursively(definitions);
+        OutgoingViewingKey::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        "FullViewingKey".into()
     }
 }
 

--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 pub mod builder;
 pub mod components;
@@ -35,7 +35,19 @@ use self::{
     txid::{to_txid, BlockTxCommitmentDigester, TxIdDigester},
 };
 
-#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+#[derive(
+    Clone,
+    Copy,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+)]
 pub struct TransparentAddress(pub [u8; 20]);
 
 pub const GROTH_PROOF_SIZE: usize = 48 + 96 + 48;

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -4,7 +4,7 @@ use std::error;
 use std::fmt;
 use std::sync::mpsc::Sender;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 
@@ -115,7 +115,7 @@ impl Progress {
 }
 
 /// Generates a [`Transaction`] from its inputs and outputs.
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct Builder<P, RN, Key = ExtendedSpendingKey, Notifier = Sender<Progress>> {
     params: P,
     rng: RN,

--- a/masp_primitives/src/transaction/components/amount.rs
+++ b/masp_primitives/src/transaction/components/amount.rs
@@ -1,4 +1,5 @@
 use crate::asset_type::AssetType;
+use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One};
 use std::cmp::Ordering;
@@ -46,7 +47,9 @@ pub type I128Sum = ValueSum<AssetType, i128>;
 
 pub type U128Sum = ValueSum<AssetType, u128>;
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Hash)]
+#[derive(
+    Clone, Default, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema, Hash,
+)]
 pub struct ValueSum<
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
     Value: BorshSerialize + BorshDeserialize + PartialEq + Eq,

--- a/masp_primitives/src/transaction/components/amount.rs
+++ b/masp_primitives/src/transaction/components/amount.rs
@@ -1,4 +1,7 @@
 use crate::asset_type::AssetType;
+use borsh::schema::add_definition;
+use borsh::schema::Fields;
+use borsh::schema::{Declaration, Definition};
 use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One};
@@ -47,9 +50,7 @@ pub type I128Sum = ValueSum<AssetType, i128>;
 
 pub type U128Sum = ValueSum<AssetType, u128>;
 
-#[derive(
-    Clone, Default, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema, Hash,
-)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct ValueSum<
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
     Value: BorshSerialize + BorshDeserialize + PartialEq + Eq,
@@ -155,6 +156,87 @@ where
         let mut val = self.clone();
         val.0.remove(&index);
         val
+    }
+}
+
+impl<Unit, Value> BorshSerialize for ValueSum<Unit, Value>
+where
+    Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
+    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy,
+{
+    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let vec: Vec<_> = self.components().collect();
+        Vector::write(writer, vec.as_ref(), |writer, elt| {
+            elt.0.serialize(writer)?;
+            elt.1.serialize(writer)?;
+            Ok(())
+        })
+    }
+}
+
+impl<Unit, Value> BorshDeserialize for ValueSum<Unit, Value>
+where
+    Unit: Hash + Ord + BorshSerialize + BorshDeserialize,
+    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq,
+{
+    fn deserialize_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        let vec = Vector::read(reader, |reader| {
+            let atype = Unit::deserialize_reader(reader)?;
+            let value = Value::deserialize_reader(reader)?;
+            Ok((atype, value))
+        })?;
+        Ok(Self(vec.into_iter().collect()))
+    }
+}
+
+impl<Unit, Value> BorshSchema for ValueSum<Unit, Value>
+where
+    Unit: Hash + Ord + BorshSerialize + BorshDeserialize + BorshSchema,
+    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq + BorshSchema,
+{
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Enum {
+            tag_width: 1,
+            variants: vec![
+                (253, "u16".into(), u16::declaration()),
+                (254, "u32".into(), u32::declaration()),
+                (255, "u64".into(), u64::declaration()),
+            ],
+        };
+        add_definition(
+            format!("{}::CompactSize", Self::declaration()),
+            definition,
+            definitions,
+        );
+        let definition = Definition::Sequence {
+            length_width: 0,
+            length_range: u64::MIN..=u64::MAX,
+            elements: <(Unit, Value)>::declaration(),
+        };
+        add_definition(
+            format!("{}::Sequence", Self::declaration()),
+            definition,
+            definitions,
+        );
+        let definition = Definition::Struct {
+            fields: Fields::UnnamedFields(vec![
+                format!("{}::CompactSize", Self::declaration()),
+                format!("{}::Sequence", Self::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        u16::add_definitions_recursively(definitions);
+        u32::add_definitions_recursively(definitions);
+        u64::add_definitions_recursively(definitions);
+        <(Unit, Value)>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        format!(
+            r#"ValueSum<{}, {}>"#,
+            Unit::declaration(),
+            Value::declaration()
+        )
     }
 }
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -248,7 +248,7 @@ impl fees::OutputView for SaplingOutputInfo {
 }
 
 /// Metadata about a transaction created by a [`SaplingBuilder`].
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct SaplingMetadata {
     spend_indices: Vec<usize>,
     convert_indices: Vec<usize>,

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -34,7 +34,12 @@ use crate::{
     },
     zip32::ExtendedSpendingKey,
 };
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::schema::add_definition;
+use borsh::schema::Declaration;
+use borsh::schema::Definition;
+use borsh::schema::Fields;
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use std::collections::BTreeMap;
 use std::io::Write;
 
 /// If there are any shielded inputs, always have at least two shielded outputs, padding
@@ -73,6 +78,30 @@ pub struct SpendDescriptionInfo<Key = ExtendedSpendingKey> {
     note: Note,
     alpha: jubjub::Fr,
     merkle_path: MerklePath<Node>,
+}
+
+impl<Key: BorshSchema> BorshSchema for SpendDescriptionInfo<Key> {
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("extsk".into(), Key::declaration()),
+                ("diversifier".into(), Diversifier::declaration()),
+                ("note".into(), Note::declaration()),
+                ("alpha".into(), <[u8; 32]>::declaration()),
+                ("merkle_path".into(), MerklePath::<[u8; 32]>::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        Key::add_definitions_recursively(definitions);
+        Diversifier::add_definitions_recursively(definitions);
+        Note::add_definitions_recursively(definitions);
+        <[u8; 32]>::add_definitions_recursively(definitions);
+        MerklePath::<[u8; 32]>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        format!(r#"SpendDescriptionInfo<{}>"#, Key::declaration())
+    }
 }
 
 impl<Key: BorshSerialize> BorshSerialize for SpendDescriptionInfo<Key> {
@@ -125,7 +154,7 @@ impl<K> fees::InputView<(), K> for SpendDescriptionInfo<K> {
 
 /// A struct containing the information required in order to construct a
 /// MASP output to a transaction.
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct SaplingOutputInfo {
     /// `None` represents the `ovk = ⊥` case.
     ovk: Option<OutgoingViewingKey>,
@@ -278,6 +307,45 @@ pub struct SaplingBuilder<P, Key = ExtendedSpendingKey> {
     spends: Vec<SpendDescriptionInfo<Key>>,
     converts: Vec<ConvertDescriptionInfo>,
     outputs: Vec<SaplingOutputInfo>,
+}
+
+impl<P: BorshSchema, Key: BorshSchema> BorshSchema for SaplingBuilder<P, Key> {
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("params".into(), P::declaration()),
+                ("spend_anchor".into(), Option::<[u8; 32]>::declaration()),
+                ("target_height".into(), BlockHeight::declaration()),
+                ("value_balance".into(), I128Sum::declaration()),
+                ("convert_anchor".into(), Option::<[u8; 32]>::declaration()),
+                (
+                    "spends".into(),
+                    Vec::<SpendDescriptionInfo<Key>>::declaration(),
+                ),
+                (
+                    "converts".into(),
+                    Vec::<ConvertDescriptionInfo>::declaration(),
+                ),
+                ("outputs".into(), Vec::<SaplingOutputInfo>::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        P::add_definitions_recursively(definitions);
+        Option::<[u8; 32]>::add_definitions_recursively(definitions);
+        BlockHeight::add_definitions_recursively(definitions);
+        I128Sum::add_definitions_recursively(definitions);
+        Vec::<SpendDescriptionInfo<Key>>::add_definitions_recursively(definitions);
+        Vec::<ConvertDescriptionInfo>::add_definitions_recursively(definitions);
+        Vec::<SaplingOutputInfo>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        format!(
+            r#"SaplingBuilder<{}, {}>"#,
+            P::declaration(),
+            Key::declaration()
+        )
+    }
 }
 
 impl<P: BorshSerialize, Key: BorshSerialize> BorshSerialize for SaplingBuilder<P, Key> {
@@ -790,6 +858,26 @@ pub struct ConvertDescriptionInfo {
     allowed: AllowedConversion,
     value: u64,
     merkle_path: MerklePath<Node>,
+}
+
+impl BorshSchema for ConvertDescriptionInfo {
+    fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("allowed".into(), AllowedConversion::declaration()),
+                ("value".into(), u64::declaration()),
+                ("merkle_path".into(), MerklePath::<[u8; 32]>::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        AllowedConversion::add_definitions_recursively(definitions);
+        u64::add_definitions_recursively(definitions);
+        MerklePath::<[u8; 32]>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> Declaration {
+        "ConvertDescriptionInfo".into()
+    }
 }
 
 impl fees::ConvertView for ConvertDescriptionInfo {

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -129,6 +129,40 @@ impl TxIn<Authorized> {
     }
 }
 
+impl BorshSerialize for TxIn<Authorized> {
+    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.write(writer)
+    }
+}
+
+impl BorshDeserialize for TxIn<Authorized> {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> io::Result<Self> {
+        Self::read(reader)
+    }
+}
+
+impl BorshSchema for TxIn<Authorized> {
+    fn add_definitions_recursively(
+        definitions: &mut BTreeMap<borsh::schema::Declaration, borsh::schema::Definition>,
+    ) {
+        let definition = Definition::Struct {
+            fields: Fields::NamedFields(vec![
+                ("asset_type".into(), AssetType::declaration()),
+                ("value".into(), u64::declaration()),
+                ("address".into(), TransparentAddress::declaration()),
+            ]),
+        };
+        add_definition(Self::declaration(), definition, definitions);
+        AssetType::add_definitions_recursively(definitions);
+        u64::add_definitions_recursively(definitions);
+        TransparentAddress::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> borsh::schema::Declaration {
+        "TxIn<Authorized>".into()
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialOrd, PartialEq, Ord, Eq)]
 pub struct TxOut {
     pub asset_type: AssetType,

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -13,6 +13,7 @@ use crate::{
         TransparentAddress,
     },
 };
+use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -45,7 +46,7 @@ impl fees::InputView for InvalidTransparentInput {
 }
 
 #[cfg(feature = "transparent-inputs")]
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema)]
 struct TransparentInputInfo {
     coin: TxOut,
 }
@@ -57,7 +58,7 @@ impl fees::InputView for TransparentInputInfo {
     }
 }
 
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
 pub struct TransparentBuilder {
     #[cfg(feature = "transparent-inputs")]
     inputs: Vec<TransparentInputInfo>,


### PR DESCRIPTION
Created Borsh schemas for `Transaction`s, `Builder`s, and their subcomponents in order to facilitate their parsing by hardware wallets. More specifically, the changes are as follows:
* Altered the `BorshSerialize` and `BorshDeserialize` of `ValueSum` to match its encoding in `Transaction`
* Implemented the `BorshSchema` trait for `Transaction`, `Builder`, and their subcomponents.
* Implemented `BorshSerialize` and `BorshDeserialize` for most of the structures that now have a `BorshSchema`. This was done by calling their pre-existing `read` and `write` methods. Hence:
  * The (de)serialization of all structures remains unchanged
  * Each structure has exactly one possible serialization
* Fixed the deserialization of Sapling bundles in the case when there are convert descriptions but no spends or outputs
* Fixed the serialization of Sapling bundles in the case when there are no spend, convert, and output descriptions