### PR TITLE
Exposed SaplingVerificationContextInner for mocking purposes.

### DIFF
--- a/masp_proofs/src/circuit/ecc.rs
+++ b/masp_proofs/src/circuit/ecc.rs
@@ -37,7 +37,7 @@ where
 
     for (i, (chunk, window)) in by.chunks(3).zip(base.iter()).enumerate() {
         let chunk_a = chunk
-            .get(0)
+            .first()
             .cloned()
             .unwrap_or_else(|| Boolean::constant(false));
         let chunk_b = chunk

--- a/masp_proofs/src/sapling/mod.rs
+++ b/masp_proofs/src/sapling/mod.rs
@@ -6,7 +6,9 @@ mod prover;
 mod verifier;
 
 pub use self::prover::SaplingProvingContext;
-pub use self::verifier::{BatchValidator, SaplingVerificationContext};
+pub use self::verifier::{
+    BatchValidator, SaplingVerificationContext, SaplingVerificationContextInner,
+};
 
 // This function computes `value` in the exponent of the value commitment base
 fn masp_compute_value_balance(asset_type: AssetType, value: i128) -> Option<jubjub::ExtendedPoint> {

--- a/masp_proofs/src/sapling/verifier.rs
+++ b/masp_proofs/src/sapling/verifier.rs
@@ -17,14 +17,14 @@ mod batch;
 pub use batch::BatchValidator;
 
 /// A context object for verifying the Sapling components of a Zcash transaction.
-struct SaplingVerificationContextInner {
+pub struct SaplingVerificationContextInner {
     // (sum of the Spend value commitments) - (sum of the Output value commitments)
     cv_sum: jubjub::ExtendedPoint,
 }
 
 impl SaplingVerificationContextInner {
     /// Construct a new context to be used with a single transaction.
-    fn new() -> Self {
+    pub fn new() -> Self {
         SaplingVerificationContextInner {
             cv_sum: jubjub::ExtendedPoint::identity(),
         }
@@ -33,7 +33,7 @@ impl SaplingVerificationContextInner {
     /// Perform consensus checks on a Sapling SpendDescription, while
     /// accumulating its value commitment inside the context for later use.
     #[allow(clippy::too_many_arguments)]
-    fn check_spend<C>(
+    pub fn check_spend<C>(
         &mut self,
         cv: jubjub::ExtendedPoint,
         anchor: bls12_381::Scalar,
@@ -101,7 +101,7 @@ impl SaplingVerificationContextInner {
     /// Perform consensus checks on a Convert SpendDescription, while
     /// accumulating its value commitment inside the context for later use.
     #[allow(clippy::too_many_arguments)]
-    fn check_convert<C>(
+    pub fn check_convert<C>(
         &mut self,
         cv: jubjub::ExtendedPoint,
         anchor: bls12_381::Scalar,
@@ -132,7 +132,7 @@ impl SaplingVerificationContextInner {
 
     /// Perform consensus checks on a Sapling OutputDescription, while
     /// accumulating its value commitment inside the context for later use.
-    fn check_output(
+    pub fn check_output(
         &mut self,
         cv: jubjub::ExtendedPoint,
         cmu: bls12_381::Scalar,
@@ -170,7 +170,7 @@ impl SaplingVerificationContextInner {
     /// Perform consensus checks on the valueBalance and bindingSig parts of a
     /// Sapling transaction. All SpendDescriptions and OutputDescriptions must
     /// have been checked before calling this function.
-    fn final_check(
+    pub fn final_check(
         &self,
         value_balance: I128Sum,
         sighash_value: &[u8; 32],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.76.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
Exposed the `SaplingVerificationContextInner` structure so that Namada can use it to make mock verification contexts.