### PR TITLE
Expose the randomness used to create descriptions.

### DIFF
--- a/masp_proofs/src/prover.rs
+++ b/masp_proofs/src/prover.rs
@@ -171,8 +171,16 @@ impl TxProver for LocalTxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
-    ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey), ()> {
-        let (proof, cv, rk) = ctx.spend_proof(
+    ) -> Result<
+        (
+            [u8; GROTH_PROOF_SIZE],
+            jubjub::ExtendedPoint,
+            jubjub::Fr,
+            PublicKey,
+        ),
+        (),
+    > {
+        let (proof, cv, rcv, rk) = ctx.spend_proof(
             proof_generation_key,
             diversifier,
             rseed,
@@ -190,7 +198,7 @@ impl TxProver for LocalTxProver {
             .write(&mut zkproof[..])
             .expect("should be able to serialize a proof");
 
-        Ok((zkproof, cv, rk))
+        Ok((zkproof, cv, rcv, rk))
     }
 
     fn output_proof(
@@ -201,8 +209,8 @@ impl TxProver for LocalTxProver {
         rcm: jubjub::Fr,
         asset_type: AssetType,
         value: u64,
-    ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
-        let (proof, cv) = ctx.output_proof(
+    ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, jubjub::Fr) {
+        let (proof, cv, rcv) = ctx.output_proof(
             esk,
             payment_address,
             rcm,
@@ -216,7 +224,7 @@ impl TxProver for LocalTxProver {
             .write(&mut zkproof[..])
             .expect("should be able to serialize a proof");
 
-        (zkproof, cv)
+        (zkproof, cv, rcv)
     }
 
     fn convert_proof(
@@ -226,8 +234,8 @@ impl TxProver for LocalTxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
-    ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()> {
-        let (proof, cv) = ctx.convert_proof(
+    ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, jubjub::Fr), ()> {
+        let (proof, cv, rcv) = ctx.convert_proof(
             allowed_conversion,
             value,
             anchor,
@@ -241,7 +249,7 @@ impl TxProver for LocalTxProver {
             .write(&mut zkproof[..])
             .expect("should be able to serialize a proof");
 
-        Ok((zkproof, cv))
+        Ok((zkproof, cv, rcv))
     }
 
     fn binding_sig(

--- a/masp_proofs/src/sapling/prover.rs
+++ b/masp_proofs/src/sapling/prover.rs
@@ -60,7 +60,7 @@ impl SaplingProvingContext {
         merkle_path: MerklePath<Node>,
         proving_key: &Parameters<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
-    ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint, PublicKey), ()> {
+    ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint, jubjub::Fr, PublicKey), ()> {
         // Initialize secure RNG
         let mut rng = OsRng;
 
@@ -155,7 +155,7 @@ impl SaplingProvingContext {
         // Accumulate the value commitment in the context
         self.cv_sum += value_commitment;
 
-        Ok((proof, value_commitment, rk))
+        Ok((proof, value_commitment, rcv, rk))
     }
 
     /// Create the value commitment and proof for a Sapling OutputDescription,
@@ -169,7 +169,7 @@ impl SaplingProvingContext {
         asset_type: AssetType,
         value: u64,
         proving_key: &Parameters<Bls12>,
-    ) -> (Proof<Bls12>, jubjub::ExtendedPoint) {
+    ) -> (Proof<Bls12>, jubjub::ExtendedPoint, jubjub::Fr) {
         // Initialize secure RNG
         let mut rng = OsRng;
 
@@ -209,7 +209,7 @@ impl SaplingProvingContext {
         // Accumulate the value commitment in the context. We do this to check internal consistency.
         self.cv_sum -= value_commitment_point; // Outputs subtract from the total.
 
-        (proof, value_commitment_point)
+        (proof, value_commitment_point, rcv)
     }
 
     /// Create the value commitment and proof for a ConvertDescription,
@@ -223,7 +223,7 @@ impl SaplingProvingContext {
         merkle_path: MerklePath<Node>,
         proving_key: &Parameters<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
-    ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint), ()> {
+    ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint, jubjub::Fr), ()> {
         // Initialize secure RNG
         let mut rng = OsRng;
 
@@ -277,7 +277,7 @@ impl SaplingProvingContext {
         // Accumulate the value commitment in the context
         self.cv_sum += value_commitment;
 
-        Ok((proof, value_commitment))
+        Ok((proof, value_commitment, rcv))
     }
 
     /// Create the bindingSig for a Sapling transaction. All calls to spend_proof()


### PR DESCRIPTION
In the course of hardware wallet implementation, it became apparent that value commitment randomness needs to be communicated to the hardware in order to allow the signing of MASP transactions in one round. This PR addresses this by exposing the randomness that was used to create value commitments in the spend, convert, and output descriptions. More precisely, it does this by extending the `SaplingMetadata` section to include `spend_rcvs: Vec<jubjub:Fr>`, `convert_rcvs: Vec<jubjub:Fr>`, and `output_rcvs: Vec<jubjub:Fr>` vectors that map positions in the description vectors to the randomness used to generate their value commitment.