### PR TITLE
Receive the randomness used to create descriptions

### DIFF
--- a/masp_primitives/src/sapling.rs
+++ b/masp_primitives/src/sapling.rs
@@ -845,7 +845,7 @@ impl<T: BorshSchema> BorshSchema for Note<T> {
     }
 
     fn declaration() -> Declaration {
-        "Note".into()
+        format!("Note<{}>", T::declaration())
     }
 }
 

--- a/masp_primitives/src/sapling/prover.rs
+++ b/masp_primitives/src/sapling/prover.rs
@@ -45,6 +45,7 @@ pub trait TxProver {
     /// while accumulating its value commitment randomness inside the context for later
     /// use.
     ///
+    #[allow(clippy::too_many_arguments)]
     fn output_proof(
         &self,
         ctx: &mut Self::SaplingProvingContext,
@@ -117,10 +118,7 @@ pub mod mock {
             _merkle_path: MerklePath<Node>,
             rcv: jubjub::Fr,
         ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey), ()> {
-            let cv = asset_type
-                .value_commitment(value, rcv)
-                .commitment()
-                .into();
+            let cv = asset_type.value_commitment(value, rcv).commitment().into();
 
             let rk =
                 PublicKey(proof_generation_key.ak.into()).randomize(ar, SPENDING_KEY_GENERATOR);
@@ -138,10 +136,7 @@ pub mod mock {
             value: u64,
             rcv: jubjub::Fr,
         ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
-            let cv = asset_type
-                .value_commitment(value, rcv)
-                .commitment()
-                .into();
+            let cv = asset_type.value_commitment(value, rcv).commitment().into();
 
             ([0u8; GROTH_PROOF_SIZE], cv)
         }

--- a/masp_primitives/src/sapling/prover.rs
+++ b/masp_primitives/src/sapling/prover.rs
@@ -38,6 +38,7 @@ pub trait TxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
+        rcv: jubjub::Fr,
     ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey), ()>;
 
     /// Create the value commitment and proof for a MASP OutputDescription,
@@ -52,6 +53,7 @@ pub trait TxProver {
         rcm: jubjub::Fr,
         asset_type: AssetType,
         value: u64,
+        rcv: jubjub::Fr,
     ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint);
 
     /// Create the value commitment, and proof for a MASP ConvertDescription,
@@ -65,6 +67,7 @@ pub trait TxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
+        rcv: jubjub::Fr,
     ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()>;
 
     /// Create the `bindingSig` for a Sapling transaction. All calls to
@@ -80,9 +83,6 @@ pub trait TxProver {
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod mock {
-    use ff::Field;
-    use rand_core::OsRng;
-
     use crate::{
         asset_type::AssetType,
         constants::SPENDING_KEY_GENERATOR,
@@ -115,11 +115,10 @@ pub mod mock {
             value: u64,
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
+            rcv: jubjub::Fr,
         ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey), ()> {
-            let mut rng = OsRng;
-
             let cv = asset_type
-                .value_commitment(value, jubjub::Fr::random(&mut rng))
+                .value_commitment(value, rcv)
                 .commitment()
                 .into();
 
@@ -137,11 +136,10 @@ pub mod mock {
             _rcm: jubjub::Fr,
             asset_type: AssetType,
             value: u64,
+            rcv: jubjub::Fr,
         ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
-            let mut rng = OsRng;
-
             let cv = asset_type
-                .value_commitment(value, jubjub::Fr::random(&mut rng))
+                .value_commitment(value, rcv)
                 .commitment()
                 .into();
 
@@ -155,11 +153,10 @@ pub mod mock {
             value: u64,
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
+            rcv: jubjub::Fr,
         ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()> {
-            let mut rng = OsRng;
-
             let cv = allowed_conversion
-                .value_commitment(value, jubjub::Fr::random(&mut rng))
+                .value_commitment(value, rcv)
                 .commitment()
                 .into();
 

--- a/masp_primitives/src/sapling/util.rs
+++ b/masp_primitives/src/sapling/util.rs
@@ -1,10 +1,10 @@
 use blake2b_simd::Params;
-use ff::Field;
-use rand_core::{CryptoRng, RngCore};
 
 use crate::consensus::{self, BlockHeight, NetworkUpgrade};
 
 use super::Rseed;
+use ff::Field;
+use rand_core::{CryptoRng, RngCore};
 
 pub fn hash_to_scalar(persona: &[u8], a: &[u8], b: &[u8]) -> jubjub::Fr {
     let mut hasher = Params::new().hash_length(64).personal(persona).to_state();
@@ -19,19 +19,24 @@ pub fn generate_random_rseed<P: consensus::Parameters, R: RngCore + CryptoRng>(
     height: BlockHeight,
     rng: &mut R,
 ) -> Rseed {
-    generate_random_rseed_internal(params, height, rng)
-}
-
-pub(crate) fn generate_random_rseed_internal<P: consensus::Parameters, R: RngCore>(
-    params: &P,
-    height: BlockHeight,
-    rng: &mut R,
-) -> Rseed {
     if params.is_nu_active(NetworkUpgrade::MASP, height) {
         let mut buffer = [0u8; 32];
         rng.fill_bytes(&mut buffer);
         Rseed::AfterZip212(buffer)
     } else {
         Rseed::BeforeZip212(jubjub::Fr::random(rng))
+    }
+}
+
+pub(crate) fn generate_random_rseed_internal<P: consensus::Parameters>(
+    params: &P,
+    height: BlockHeight,
+    before: jubjub::Fr,
+    after: [u8; 32],
+) -> Rseed {
+    if params.is_nu_active(NetworkUpgrade::MASP, height) {
+        Rseed::AfterZip212(after)
+    } else {
+        Rseed::BeforeZip212(before)
     }
 }

--- a/masp_proofs/src/prover.rs
+++ b/masp_proofs/src/prover.rs
@@ -171,6 +171,7 @@ impl TxProver for LocalTxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
+        rcv: jubjub::Fr,
     ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey), ()> {
         let (proof, cv, rk) = ctx.spend_proof(
             proof_generation_key,
@@ -183,6 +184,7 @@ impl TxProver for LocalTxProver {
             merkle_path,
             &self.spend_params,
             &self.spend_vk,
+            rcv,
         )?;
 
         let mut zkproof = [0u8; GROTH_PROOF_SIZE];
@@ -201,6 +203,7 @@ impl TxProver for LocalTxProver {
         rcm: jubjub::Fr,
         asset_type: AssetType,
         value: u64,
+        rcv: jubjub::Fr,
     ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
         let (proof, cv) = ctx.output_proof(
             esk,
@@ -209,6 +212,7 @@ impl TxProver for LocalTxProver {
             asset_type,
             value,
             &self.output_params,
+            rcv,
         );
 
         let mut zkproof = [0u8; GROTH_PROOF_SIZE];
@@ -226,6 +230,7 @@ impl TxProver for LocalTxProver {
         value: u64,
         anchor: bls12_381::Scalar,
         merkle_path: MerklePath<Node>,
+        rcv: jubjub::Fr,
     ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()> {
         let (proof, cv) = ctx.convert_proof(
             allowed_conversion,
@@ -234,6 +239,7 @@ impl TxProver for LocalTxProver {
             merkle_path,
             &self.convert_params,
             &self.convert_vk,
+            rcv,
         )?;
 
         let mut zkproof = [0u8; GROTH_PROOF_SIZE];

--- a/masp_proofs/src/sapling/prover.rs
+++ b/masp_proofs/src/sapling/prover.rs
@@ -159,6 +159,7 @@ impl SaplingProvingContext {
     /// Create the value commitment and proof for a Sapling OutputDescription,
     /// while accumulating its value commitment randomness inside the context
     /// for later use.
+    #[allow(clippy::too_many_arguments)]
     pub fn output_proof(
         &mut self,
         esk: jubjub::Fr,
@@ -209,6 +210,7 @@ impl SaplingProvingContext {
     /// Create the value commitment and proof for a ConvertDescription,
     /// while accumulating its value commitment randomness inside the context
     /// for later use.
+    #[allow(clippy::too_many_arguments)]
     pub fn convert_proof(
         &mut self,
         allowed_conversion: AllowedConversion,

--- a/masp_proofs/src/sapling/prover.rs
+++ b/masp_proofs/src/sapling/prover.rs
@@ -3,7 +3,7 @@ use bellman::{
     groth16::{create_random_proof, verify_proof, Parameters, PreparedVerifyingKey, Proof},
 };
 use bls12_381::Bls12;
-use group::{ff::Field, Curve, GroupEncoding};
+use group::{Curve, GroupEncoding};
 use masp_primitives::{
     asset_type::AssetType,
     constants::{SPENDING_KEY_GENERATOR, VALUE_COMMITMENT_RANDOMNESS_GENERATOR},
@@ -60,12 +60,10 @@ impl SaplingProvingContext {
         merkle_path: MerklePath<Node>,
         proving_key: &Parameters<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
+        rcv: jubjub::Fr,
     ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint, PublicKey), ()> {
         // Initialize secure RNG
         let mut rng = OsRng;
-
-        // We create the randomness of the value commitment
-        let rcv = jubjub::Fr::random(&mut rng);
 
         // Accumulate the value commitment randomness in the context
         {
@@ -169,14 +167,10 @@ impl SaplingProvingContext {
         asset_type: AssetType,
         value: u64,
         proving_key: &Parameters<Bls12>,
+        rcv: jubjub::Fr,
     ) -> (Proof<Bls12>, jubjub::ExtendedPoint) {
         // Initialize secure RNG
         let mut rng = OsRng;
-
-        // We construct ephemeral randomness for the value commitment. This
-        // randomness is not given back to the caller, but the synthetic
-        // blinding factor `bsk` is accumulated in the context.
-        let rcv = jubjub::Fr::random(&mut rng);
 
         // Accumulate the value commitment randomness in the context
         {
@@ -223,12 +217,10 @@ impl SaplingProvingContext {
         merkle_path: MerklePath<Node>,
         proving_key: &Parameters<Bls12>,
         verifying_key: &PreparedVerifyingKey<Bls12>,
+        rcv: jubjub::Fr,
     ) -> Result<(Proof<Bls12>, jubjub::ExtendedPoint), ()> {
         // Initialize secure RNG
         let mut rng = OsRng;
-
-        // We create the randomness of the value commitment
-        let rcv = jubjub::Fr::random(&mut rng);
 
         // Accumulate the value commitment randomness in the context
         {


### PR DESCRIPTION
Allow the MASP transaction builder to receive certain parameters instead of generating them or computing them. Doing this is necessary in order to allow hardware wallets to generate the randomness used in a transaction. The following parameters can now be sent to a transaction builder:
* Spend description:
  * Value commitment randomness
  * Spend authorization randomizer
  * Spend authorization signature
  * Proof generation key
* Convert description:
  * Value commitment randomness
* Output description:
  * Value commitment randomness
  * Note RCM value
  * Note rseed value