### PR TITLE
Guarantee success in ValueSum::from_pair.

### DIFF
--- a/masp_primitives/src/convert.rs
+++ b/masp_primitives/src/convert.rs
@@ -223,12 +223,11 @@ mod tests {
     #[test]
     fn test_homomorphism() {
         // Left operand
-        let a = ValueSum::from_pair(zec(), 5i128).unwrap()
-            + ValueSum::from_pair(btc(), 6i128).unwrap()
-            + ValueSum::from_pair(xan(), 7i128).unwrap();
+        let a = ValueSum::from_pair(zec(), 5i128)
+            + ValueSum::from_pair(btc(), 6i128)
+            + ValueSum::from_pair(xan(), 7i128);
         // Right operand
-        let b = ValueSum::from_pair(zec(), 2i128).unwrap()
-            + ValueSum::from_pair(xan(), 10i128).unwrap();
+        let b = ValueSum::from_pair(zec(), 2i128) + ValueSum::from_pair(xan(), 10i128);
         // Test homomorphism
         assert_eq!(
             AllowedConversion::from(a.clone() + b.clone()),
@@ -238,9 +237,9 @@ mod tests {
     #[test]
     fn test_serialization() {
         // Make conversion
-        let a: AllowedConversion = (ValueSum::from_pair(zec(), 5i128).unwrap()
-            + ValueSum::from_pair(btc(), 6i128).unwrap()
-            + ValueSum::from_pair(xan(), 7i128).unwrap())
+        let a: AllowedConversion = (ValueSum::from_pair(zec(), 5i128)
+            + ValueSum::from_pair(btc(), 6i128)
+            + ValueSum::from_pair(xan(), 7i128))
         .into();
         // Serialize conversion
         let mut data = Vec::new();

--- a/masp_primitives/src/transaction/builder.rs
+++ b/masp_primitives/src/transaction/builder.rs
@@ -292,13 +292,13 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
     }
 
     /// Returns the sum of the transparent, Sapling, and TZE value balances.
-    pub fn value_balance(&self) -> Result<I128Sum, BalanceError> {
+    pub fn value_balance(&self) -> I128Sum {
         let value_balances = [
-            self.transparent_builder.value_balance()?,
+            self.transparent_builder.value_balance(),
             self.sapling_builder.value_balance(),
         ];
 
-        Ok(value_balances.into_iter().sum::<I128Sum>())
+        value_balances.into_iter().sum::<I128Sum>()
     }
 
     /// Builds a transaction from the configured spends and outputs.
@@ -337,7 +337,7 @@ impl<P: consensus::Parameters, R: RngCore> Builder<P, R> {
         //
 
         // After fees are accounted for, the value balance of the transaction must be zero.
-        let balance_after_fees = self.value_balance()? - I128Sum::from_sum(fee);
+        let balance_after_fees = self.value_balance() - I128Sum::from_sum(fee);
 
         if balance_after_fees != ValueSum::zero() {
             return Err(Error::InsufficientFunds(-balance_after_fees));
@@ -600,8 +600,7 @@ mod tests {
             assert_eq!(
                 builder.mock_build(),
                 Err(Error::InsufficientFunds(
-                    I128Sum::from_pair(zec(), 50000).unwrap()
-                        + &I128Sum::from_sum(DEFAULT_FEE.clone())
+                    I128Sum::from_pair(zec(), 50000) + &I128Sum::from_sum(DEFAULT_FEE.clone())
                 ))
             );
         }
@@ -616,8 +615,7 @@ mod tests {
             assert_eq!(
                 builder.mock_build(),
                 Err(Error::InsufficientFunds(
-                    I128Sum::from_pair(zec(), 50000).unwrap()
-                        + &I128Sum::from_sum(DEFAULT_FEE.clone())
+                    I128Sum::from_pair(zec(), 50000) + &I128Sum::from_sum(DEFAULT_FEE.clone())
                 ))
             );
         }
@@ -649,9 +647,7 @@ mod tests {
                 .unwrap();
             assert_eq!(
                 builder.mock_build(),
-                Err(Error::InsufficientFunds(
-                    ValueSum::from_pair(zec(), 1).unwrap()
-                ))
+                Err(Error::InsufficientFunds(ValueSum::from_pair(zec(), 1)))
             );
         }
 

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -470,8 +470,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
 
         let alpha = jubjub::Fr::random(&mut rng);
 
-        self.value_balance += ValueSum::from_pair(note.asset_type, note.value.into())
-            .map_err(|_| Error::InvalidAmount)?;
+        self.value_balance += ValueSum::from_pair(note.asset_type, note.value.into());
 
         self.spends.push(SpendDescriptionInfo {
             extsk,
@@ -540,8 +539,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             memo,
         )?;
 
-        self.value_balance -=
-            ValueSum::from_pair(asset_type, value.into()).map_err(|_| Error::InvalidAmount)?;
+        self.value_balance -= ValueSum::from_pair(asset_type, value.into());
 
         self.outputs.push(output);
 

--- a/masp_primitives/src/transaction/components/transparent.rs
+++ b/masp_primitives/src/transaction/components/transparent.rs
@@ -63,7 +63,7 @@ impl<A: Authorization> Bundle<A> {
     /// transferred out of the transparent pool into shielded pools or to fees; a negative value
     /// means that the containing transaction has funds being transferred into the transparent pool
     /// from the shielded pools.
-    pub fn value_balance<E, F>(&self) -> Result<I128Sum, E>
+    pub fn value_balance<E, F>(&self) -> I128Sum
     where
         E: From<BalanceError>,
     {
@@ -71,18 +71,16 @@ impl<A: Authorization> Bundle<A> {
             .vin
             .iter()
             .map(|p| ValueSum::from_pair(p.asset_type, p.value as i128))
-            .sum::<Result<I128Sum, ()>>()
-            .map_err(|_| BalanceError::Overflow)?;
+            .sum::<I128Sum>();
 
         let output_sum = self
             .vout
             .iter()
             .map(|p| ValueSum::from_pair(p.asset_type, p.value as i128))
-            .sum::<Result<I128Sum, ()>>()
-            .map_err(|_| BalanceError::Overflow)?;
+            .sum::<I128Sum>();
 
         // Cannot panic when subtracting two positive i64
-        Ok(input_sum - output_sum)
+        input_sum - output_sum
     }
 }
 

--- a/masp_primitives/src/transaction/components/transparent/builder.rs
+++ b/masp_primitives/src/transaction/components/transparent/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     asset_type::AssetType,
     transaction::{
         components::{
-            amount::{BalanceError, I128Sum, ValueSum, MAX_MONEY},
+            amount::{I128Sum, ValueSum, MAX_MONEY},
             transparent::{self, fees, Authorization, Authorized, Bundle, TxIn, TxOut},
         },
         sighash::TransparentAuthorizingContext,
@@ -130,14 +130,13 @@ impl TransparentBuilder {
         Ok(())
     }
 
-    pub fn value_balance(&self) -> Result<I128Sum, BalanceError> {
+    pub fn value_balance(&self) -> I128Sum {
         #[cfg(feature = "transparent-inputs")]
         let input_sum = self
             .inputs
             .iter()
             .map(|input| ValueSum::from_pair(input.coin.asset_type, input.coin.value as i128))
-            .sum::<Result<I128Sum, ()>>()
-            .map_err(|_| BalanceError::Overflow)?;
+            .sum::<I128Sum>();
 
         #[cfg(not(feature = "transparent-inputs"))]
         let input_sum = ValueSum::zero();
@@ -146,11 +145,10 @@ impl TransparentBuilder {
             .vout
             .iter()
             .map(|vo| ValueSum::from_pair(vo.asset_type, vo.value as i128))
-            .sum::<Result<I128Sum, ()>>()
-            .map_err(|_| BalanceError::Overflow)?;
+            .sum::<I128Sum>();
 
         // Cannot panic when subtracting two positive i64
-        Ok(input_sum - output_sum)
+        input_sum - output_sum
     }
 
     pub fn build(self) -> Option<transparent::Bundle<Unauthorized>> {

--- a/masp_proofs/benches/convert.rs
+++ b/masp_proofs/benches/convert.rs
@@ -39,9 +39,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mint_value = i as i128 + 1;
 
         let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
-            .unwrap()
-            + ValueSum::from_pair(output_asset, output_value).unwrap()
-            + ValueSum::from_pair(mint_asset, mint_value).unwrap())
+            + ValueSum::from_pair(output_asset, output_value)
+            + ValueSum::from_pair(mint_asset, mint_value))
         .into();
 
         let value = rng.next_u64();

--- a/masp_proofs/src/circuit/convert.rs
+++ b/masp_proofs/src/circuit/convert.rs
@@ -155,9 +155,8 @@ fn test_convert_circuit_with_bls12_381() {
         let mint_value = i as i128 + 1;
 
         let allowed_conversion: AllowedConversion = (ValueSum::from_pair(spend_asset, spend_value)
-            .unwrap()
-            + ValueSum::from_pair(output_asset, output_value).unwrap()
-            + ValueSum::from_pair(mint_asset, mint_value).unwrap())
+            + ValueSum::from_pair(output_asset, output_value)
+            + ValueSum::from_pair(mint_asset, mint_value))
         .into();
 
         let value = rng.next_u64();


### PR DESCRIPTION
Make `ValueSum::from_pair` return a `ValueSum` instead of a `Result<ValueSum, _>`. This makes this frequently used function easier to use. Given that `Result::Ok` was always returned before, it's safe to now remove all the `Result::unwrap`s and `Result::map_err`s that surrounded each `ValueSum::from_pair` call.