### PR TITLE
Murisi/alternative num traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,8 +920,7 @@ dependencies = [
  "masp_note_encryption",
  "memuse",
  "nonempty",
- "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.19 (git+https://github.com/heliaxdev/num-traits?rev=e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38)",
+ "num-traits 0.2.19 (git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe)",
  "proptest",
  "rand",
  "rand_core",
@@ -1057,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "git+https://github.com/heliaxdev/num-traits?rev=e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38#e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38"
+source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
  "criterion-plot",
  "itertools 0.10.5",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "oorandom",
  "plotters",
  "rayon",
@@ -617,7 +617,7 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -920,7 +920,8 @@ dependencies = [
  "masp_note_encryption",
  "memuse",
  "nonempty",
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.19 (git+https://github.com/heliaxdev/num-traits?rev=e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38)",
  "proptest",
  "rand",
  "rand_core",
@@ -1021,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1040,7 +1041,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1051,6 +1052,14 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "git+https://github.com/heliaxdev/num-traits?rev=e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38#e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1174,7 +1183,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -1286,7 +1295,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.5.0",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "rand_chacha",
  "rand_xorshift",

--- a/masp_primitives/Cargo.toml
+++ b/masp_primitives/Cargo.toml
@@ -37,8 +37,7 @@ sha2 = "0.10"
 memuse = "0.2.1"
 
 # - Checked arithmetic
-num-traits = "0.2.14"
-num-traits-decoupled = { package = "num-traits", version = "0.2.19", git = "https://github.com/heliaxdev/num-traits", rev = "e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38" }
+num-traits = { version = "0.2.19", git = "https://github.com/heliaxdev/num-traits", rev = "3f3657caa34b8e116fdf3f8a3519c4ac29f012fe" }
 
 # - Secret management
 subtle = "2.2.3"

--- a/masp_primitives/Cargo.toml
+++ b/masp_primitives/Cargo.toml
@@ -38,6 +38,7 @@ memuse = "0.2.1"
 
 # - Checked arithmetic
 num-traits = "0.2.14"
+num-traits-decoupled = { package = "num-traits", version = "0.2.19", git = "https://github.com/heliaxdev/num-traits", rev = "e3e712fc4ecbf9d95399b0b98ee9f3d6b9973e38" }
 
 # - Secret management
 subtle = "2.2.3"

--- a/masp_primitives/src/lib.rs
+++ b/masp_primitives/src/lib.rs
@@ -30,6 +30,7 @@ pub use bls12_381;
 pub use ff;
 pub use group;
 pub use jubjub;
+pub use num_traits;
 
 #[cfg(test)]
 mod test_vectors;

--- a/masp_primitives/src/transaction/components/amount.rs
+++ b/masp_primitives/src/transaction/components/amount.rs
@@ -4,7 +4,7 @@ use borsh::schema::Fields;
 use borsh::schema::{Declaration, Definition};
 use borsh::BorshSchema;
 use borsh::{BorshDeserialize, BorshSerialize};
-use num_traits_decoupled::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One};
+use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One};
 use std::cmp::Ordering;
 use std::collections::btree_map::Keys;
 use std::collections::btree_map::{IntoIter, Iter};
@@ -412,39 +412,33 @@ impl_index!(i128);
 
 impl_index!(u128);
 
-impl<Unit, Value> MulAssign<Value> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> MulAssign<Rhs> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
+    Lhs: BorshSerialize
         + BorshDeserialize
         + PartialEq
         + Eq
         + Copy
         + Default
-        + PartialOrd
-        + CheckedMul<Output = Value>,
+        + CheckedMul<Rhs, Output = Lhs>,
+    Rhs: Copy,
 {
-    fn mul_assign(&mut self, rhs: Value) {
+    fn mul_assign(&mut self, rhs: Rhs) {
         *self = self.clone() * rhs;
     }
 }
 
-impl<Unit, Value> Mul<Value> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> Mul<Rhs> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
-        + BorshDeserialize
-        + PartialEq
-        + Eq
-        + Copy
-        + Default
-        + PartialOrd
-        + CheckedMul,
-    <Value as CheckedMul>::Output : Default + BorshSerialize + BorshDeserialize + Eq,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedMul<Rhs>,
+    Rhs: Copy,
+    <Lhs as CheckedMul<Rhs>>::Output: Default + BorshSerialize + BorshDeserialize + Eq,
 {
-    type Output = ValueSum<Unit, <Value as CheckedMul>::Output>;
+    type Output = ValueSum<Unit, <Lhs as CheckedMul<Rhs>>::Output>;
 
-    fn mul(self, rhs: Value) -> Self::Output {
+    fn mul(self, rhs: Rhs) -> Self::Output {
         let mut comps = BTreeMap::new();
         for (atype, amount) in self.0.iter() {
             comps.insert(
@@ -452,137 +446,125 @@ where
                 amount.checked_mul(rhs).expect("overflow detected"),
             );
         }
-        comps.retain(|_, v| *v != <Value as CheckedMul>::Output::default());
+        comps.retain(|_, v| *v != <Lhs as CheckedMul<Rhs>>::Output::default());
         ValueSum(comps)
     }
 }
 
-impl<Unit, Value> AddAssign<&ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> AddAssign<&ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
+    Lhs: BorshSerialize
         + BorshDeserialize
         + PartialEq
         + Eq
         + Copy
         + Default
-        + PartialOrd
-        + CheckedAdd<Output = Value>,
+        + CheckedAdd<Rhs, Output = Lhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
 {
-    fn add_assign(&mut self, rhs: &ValueSum<Unit, Value>) {
+    fn add_assign(&mut self, rhs: &ValueSum<Unit, Rhs>) {
         *self = self.clone() + rhs;
     }
 }
 
-impl<Unit, Value> AddAssign<ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> AddAssign<ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
+    Lhs: BorshSerialize
         + BorshDeserialize
         + PartialEq
         + Eq
         + Copy
         + Default
-        + PartialOrd
-        + CheckedAdd<Output = Value>,
+        + CheckedAdd<Rhs, Output = Lhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
 {
-    fn add_assign(&mut self, rhs: ValueSum<Unit, Value>) {
+    fn add_assign(&mut self, rhs: ValueSum<Unit, Rhs>) {
         *self += &rhs
     }
 }
 
-impl<Unit, Value> Add<&ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> Add<&ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
-        + BorshDeserialize
-        + PartialEq
-        + Eq
-        + Copy
-        + Default
-        + PartialOrd
-        + CheckedAdd<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedAdd<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedAdd<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
+    type Output = ValueSum<Unit, <Lhs as CheckedAdd<Rhs>>::Output>;
 
-    fn add(self, rhs: &ValueSum<Unit, Value>) -> Self::Output {
+    fn add(self, rhs: &ValueSum<Unit, Rhs>) -> Self::Output {
         self.checked_add(rhs).expect("overflow detected")
     }
 }
 
-impl<Unit, Value> Add<ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> Add<ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
-        + BorshDeserialize
-        + PartialEq
-        + Eq
-        + Copy
-        + Default
-        + PartialOrd
-        + CheckedAdd<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedAdd<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedAdd<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
+    type Output = ValueSum<Unit, <Lhs as CheckedAdd<Rhs>>::Output>;
 
-    fn add(self, rhs: ValueSum<Unit, Value>) -> Self::Output {
+    fn add(self, rhs: ValueSum<Unit, Rhs>) -> Self::Output {
         self + &rhs
     }
 }
 
-impl<Unit, Value> CheckedAdd for &ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> CheckedAdd<&ValueSum<Unit, Rhs>> for &ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
-        + BorshDeserialize
-        + PartialEq
-        + Eq
-        + Copy
-        + Default
-        + PartialOrd
-        + CheckedAdd<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedAdd<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedAdd<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
-    
-    fn checked_add(self, v: Self) -> Option<Self::Output> {
-        let mut comps = self.0.clone();
+    type Output = ValueSum<Unit, <Lhs as CheckedAdd<Rhs>>::Output>;
+
+    fn checked_add(self, v: &ValueSum<Unit, Rhs>) -> Option<Self::Output> {
+        let mut comps = BTreeMap::new();
+        for (atype, amount) in self.components() {
+            comps.insert(atype.clone(), amount.checked_add(Rhs::default())?);
+        }
         for (atype, amount) in v.components() {
             comps.insert(atype.clone(), self.get(atype).checked_add(*amount)?);
         }
-        comps.retain(|_, v| *v != Value::default());
+        comps.retain(|_, v| *v != <Lhs as CheckedAdd<Rhs>>::Output::default());
         Some(ValueSum(comps))
     }
 }
 
-impl<Unit, Value> SubAssign<&ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> SubAssign<&ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
+    Lhs: BorshSerialize
         + BorshDeserialize
         + PartialEq
         + Eq
         + Copy
         + Default
-        + PartialOrd
-        + CheckedSub<Output = Value>,
+        + CheckedSub<Rhs, Output = Lhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
 {
-    fn sub_assign(&mut self, rhs: &ValueSum<Unit, Value>) {
+    fn sub_assign(&mut self, rhs: &ValueSum<Unit, Rhs>) {
         *self = self.clone() - rhs
     }
 }
 
-impl<Unit, Value> SubAssign<ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> SubAssign<ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize
+    Lhs: BorshSerialize
         + BorshDeserialize
         + PartialEq
         + Eq
         + Copy
         + Default
-        + PartialOrd
-        + CheckedSub<Output = Value>,
+        + CheckedSub<Rhs, Output = Lhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
 {
-    fn sub_assign(&mut self, rhs: ValueSum<Unit, Value>) {
+    fn sub_assign(&mut self, rhs: ValueSum<Unit, Rhs>) {
         *self -= &rhs
     }
 }
@@ -615,43 +597,52 @@ where
     }
 }
 
-impl<Unit, Value> Sub<&ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> Sub<&ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedSub<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
+    type Output = ValueSum<Unit, <Lhs as CheckedSub<Rhs>>::Output>;
 
-    fn sub(self, rhs: &ValueSum<Unit, Value>) -> Self::Output {
+    fn sub(self, rhs: &ValueSum<Unit, Rhs>) -> Self::Output {
         self.checked_sub(rhs).expect("underflow detected")
     }
 }
 
-impl<Unit, Value> Sub<ValueSum<Unit, Value>> for ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> Sub<ValueSum<Unit, Rhs>> for ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedSub<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
+    type Output = ValueSum<Unit, <Lhs as CheckedSub<Rhs>>::Output>;
 
-    fn sub(self, rhs: ValueSum<Unit, Value>) -> Self::Output {
+    fn sub(self, rhs: ValueSum<Unit, Rhs>) -> Self::Output {
         self - &rhs
     }
 }
 
-impl<Unit, Value> CheckedSub for &ValueSum<Unit, Value>
+impl<Unit, Lhs, Rhs> CheckedSub<&ValueSum<Unit, Rhs>> for &ValueSum<Unit, Lhs>
 where
     Unit: Hash + Ord + BorshSerialize + BorshDeserialize + Clone,
-    Value: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Output = Value>,
+    Lhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default + CheckedSub<Rhs>,
+    Rhs: BorshSerialize + BorshDeserialize + PartialEq + Eq + Copy + Default,
+    <Lhs as CheckedSub<Rhs>>::Output: BorshSerialize + BorshDeserialize + Eq + Default,
 {
-    type Output = ValueSum<Unit, Value>;
-    
-    fn checked_sub(self, v: Self) -> Option<Self::Output> {
-        let mut comps = self.0.clone();
+    type Output = ValueSum<Unit, <Lhs as CheckedSub<Rhs>>::Output>;
+
+    fn checked_sub(self, v: &ValueSum<Unit, Rhs>) -> Option<Self::Output> {
+        let mut comps = BTreeMap::new();
+        for (atype, amount) in self.components() {
+            comps.insert(atype.clone(), amount.checked_sub(Rhs::default())?);
+        }
         for (atype, amount) in v.components() {
             comps.insert(atype.clone(), self.get(atype).checked_sub(*amount)?);
         }
-        comps.retain(|_, v| *v != Value::default());
+        comps.retain(|_, v| *v != <Lhs as CheckedSub<Rhs>>::Output::default());
         Some(ValueSum(comps))
     }
 }

--- a/masp_primitives/src/transaction/components/sapling/builder.rs
+++ b/masp_primitives/src/transaction/components/sapling/builder.rs
@@ -652,7 +652,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
             self.spend_anchor = Some(merkle_path.root(node).into())
         }
 
-        self.value_balance += ValueSum::from_pair(note.asset_type, note.value.into());
+        self.value_balance += ValueSum::from_pair(note.asset_type, i128::from(note.value));
 
         self.spends.push(SpendDescriptionInfo {
             extsk,
@@ -710,7 +710,7 @@ impl<P: consensus::Parameters> SaplingBuilder<P> {
     ) -> Result<(), Error> {
         let output = SaplingOutputInfo::new_internal(ovk, to, asset_type, value, memo)?;
 
-        self.value_balance -= ValueSum::from_pair(asset_type, value.into());
+        self.value_balance -= ValueSum::from_pair(asset_type, i128::from(value));
 
         self.outputs.push(output);
 


### PR DESCRIPTION
This PR makes the MASP primitives crate use the `num_traits` crate at https://github.com/heliaxdev/num-traits/pull/1 . This is required because the traits originally required by this crate forced the implementer to also implement unchecked arithmetic operations, which is something that is no longer allowed in Namada for safety reasons.