### PR TITLE
Allow Borsh (de)serialization of TxIds.

### DIFF
--- a/masp_primitives/src/transaction.rs
+++ b/masp_primitives/src/transaction.rs
@@ -60,7 +60,9 @@ pub type GrothProofBytes = [u8; GROTH_PROOF_SIZE];
 const MASPV5_TX_VERSION: u32 = 2;
 const MASPV5_VERSION_GROUP_ID: u32 = 0x26A7270A;
 
-#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(
+    Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
 pub struct TxId([u8; 32]);
 
 memuse::impl_no_dynamic_usage!(TxId);


### PR DESCRIPTION
This PR enables the Borsh (de)serialization of `TxId`s. This is required in order to allow `TxId`s to be used inside Namada structures that need serialization support.