### PR TITLE
fix internal deps versions for publishing

### DIFF
--- a/masp_primitives/Cargo.toml
+++ b/masp_primitives/Cargo.toml
@@ -77,7 +77,7 @@ borsh = {version = "1.2.0", features = ["unstable__schema", "derive"]}
 arbitrary = {version = "1.3", features = ["derive"], optional = true }
 
 [dependencies.masp_note_encryption]
-version = "1.0.0"
+version = "1.2.0"
 path = "../masp_note_encryption"
 features = ["pre-zip-212"]
 

--- a/masp_proofs/Cargo.toml
+++ b/masp_proofs/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography::cryptocurrencies"]
 all-features = true
 
 [dependencies]
-masp_primitives = { version = "1.0.0", path = "../masp_primitives" }
+masp_primitives = { version = "1.2.0", path = "../masp_primitives" }
 
 # Dependencies exposed in a public API:
 # (Breaking upgrades to these require a breaking upgrade to this crate.)


### PR DESCRIPTION
This has to be the version that will be published - i.e. 1.2.0